### PR TITLE
chore: Return light mode elevation to prior colors

### DIFF
--- a/src/kit/Theme/themeUtils.ts
+++ b/src/kit/Theme/themeUtils.ts
@@ -199,8 +199,8 @@ const themeLight = {
 
   // Elevation styles
   elevation0Bg: '#F0F0F0',
-  elevation1Bg: '#F7F7F7',
-  elevation2Bg: '#FDFDFD',
+  elevation1Bg: '#FAFAFA',
+  elevation2Bg: '#FFF',
   elevation3Bg: '#FFF',
   elevation4Bg: '#FFF',
   elevation0Hover: '#ECECEC',


### PR DESCRIPTION
This PR changes the elevation colors for light mode to match what we currently have on latest-main. This will reduce the number of visual changes that happen while we adopt the new theme system.