### PR TITLE
feat: Add Glossary component to kit

### DIFF
--- a/src/DesignKit.tsx
+++ b/src/DesignKit.tsx
@@ -2721,7 +2721,8 @@ const GlossarySection: React.FC = () => {
     <ComponentSection id="Glossary" title="Glossary">
       <AntDCard>
         <p>
-          A <code>{'<Glossary>'}</code> component
+          A Glossary <code>{'<Glossary>'}</code> component displays a series of terms alongside
+          their definitions or values.
         </p>
       </AntDCard>
       <AntDCard title="Usage">

--- a/src/DesignKit.tsx
+++ b/src/DesignKit.tsx
@@ -17,6 +17,7 @@ import DatePicker from 'kit/DatePicker';
 import Drawer from 'kit/Drawer';
 import Dropdown, { MenuItem } from 'kit/Dropdown';
 import Form from 'kit/Form';
+import Glossary from 'kit/Glossary';
 import Icon, { IconNameArray, IconSizeArray } from 'kit/Icon';
 import InlineForm from 'kit/InlineForm';
 import Input from 'kit/Input';
@@ -97,6 +98,7 @@ const ComponentTitles = {
   Drawer: 'Drawer',
   Dropdown: 'Dropdown',
   Form: 'Form',
+  Glossary: 'Glossary',
   Icons: 'Icons',
   InlineForm: 'InlineForm',
   Input: 'Input',
@@ -2714,6 +2716,27 @@ const ColumnsSection: React.FC = () => {
   );
 };
 
+const GlossarySection: React.FC = () => {
+  return (
+    <ComponentSection id="Glossary" title="Glossary">
+      <AntDCard>
+        <p>
+          A <code>{'<Glossary>'}</code> component
+        </p>
+      </AntDCard>
+      <AntDCard title="Usage">
+        <Glossary
+          content={[
+            { label: 'Key', value: 'Value' },
+            { label: 'Multiple Values', value: ['Value 1', 'Value 2', 'Value 3'] },
+            { label: 'Component Value', value: <Surface>Arbitrary component</Surface> },
+          ]}
+        />
+      </AntDCard>
+    </ComponentSection>
+  );
+};
+
 const IconsSection: React.FC = () => {
   return (
     <ComponentSection id="Icons" title="Icons">
@@ -3456,6 +3479,7 @@ const Components = {
   Drawer: <DrawerSection />,
   Dropdown: <DropdownSection />,
   Form: <FormSection />,
+  Glossary: <GlossarySection />,
   Icons: <IconsSection />,
   InlineForm: <InlineFormSection />,
   Input: <InputSection />,

--- a/src/kit/Glossary.module.scss
+++ b/src/kit/Glossary.module.scss
@@ -1,0 +1,52 @@
+.base {
+  color: var(--theme-colors-monochrome-9);
+  font-size: 16px;
+  margin: 0;
+
+  .header {
+    color: var(--theme-colors-monochrome-7);
+    font-size: 16px;
+    font-weight: 600;
+  }
+  .separator {
+    border-top: 1px solid var(--theme-colors-monochrome-13);
+  }
+  .info {
+    align-items: center;
+    display: flex;
+    padding: 4px 0;
+
+    &:first-of-type {
+      border-top: none;
+    }
+    .label {
+      align-self: flex-start;
+      color: var(--theme-colors-monochrome-8);
+      flex-basis: 34%;
+      flex-shrink: 0;
+      font-size: 12px;
+      margin-right: 20px;
+      max-width: 200px;
+      min-width: 50px;
+      padding-right: 8px;
+    }
+    .content {
+      color: var(--theme-colors-monochrome-6);
+      flex-basis: 66%;
+      flex-grow: 1;
+      font-size: 14px;
+      margin: 0;
+      min-width: 0;
+
+      .blank {
+        background-color: var(--theme-background-on);
+      }
+    }
+    .contentList {
+      color: var(--theme-colors-monochrome-6);
+      flex-basis: 66%;
+      flex-grow: 1;
+      font-size: 14px;
+    }
+  }
+}

--- a/src/kit/Glossary.module.scss
+++ b/src/kit/Glossary.module.scss
@@ -1,52 +1,30 @@
 .base {
-  color: var(--theme-colors-monochrome-9);
+  color: var(--theme-surface-on);
   font-size: 16px;
   margin: 0;
 
-  .header {
-    color: var(--theme-colors-monochrome-7);
-    font-size: 16px;
-    font-weight: 600;
-  }
-  .separator {
-    border-top: 1px solid var(--theme-colors-monochrome-13);
-  }
-  .info {
+  .row {
     align-items: center;
     display: flex;
     padding: 4px 0;
 
-    &:first-of-type {
-      border-top: none;
-    }
     .label {
       align-self: flex-start;
-      color: var(--theme-colors-monochrome-8);
-      flex-basis: 34%;
-      flex-shrink: 0;
+      flex: 0 0 34%;
       font-size: 12px;
       margin-right: 20px;
       max-width: 200px;
       min-width: 50px;
       padding-right: 8px;
     }
-    .content {
-      color: var(--theme-colors-monochrome-6);
-      flex-basis: 66%;
-      flex-grow: 1;
+    .valueList {
+      flex: 1 66%;
       font-size: 14px;
-      margin: 0;
-      min-width: 0;
 
-      .blank {
-        background-color: var(--theme-background-on);
+      .value {
+        margin: 0;
+        min-width: 0;
       }
-    }
-    .contentList {
-      color: var(--theme-colors-monochrome-6);
-      flex-basis: 66%;
-      flex-grow: 1;
-      font-size: 14px;
     }
   }
 }

--- a/src/kit/Glossary.tsx
+++ b/src/kit/Glossary.tsx
@@ -1,53 +1,39 @@
 import React from 'react';
 
 import css from './Glossary.module.scss';
+import { ensureArray } from './internal/functions';
 
 export interface InfoRow {
-  content?: React.ReactNode | React.ReactNode[];
-  label: React.ReactNode;
-}
-
-interface InfoRowProps extends InfoRow {
-  separator: boolean;
+  value: string | React.ReactElement | (string | React.ReactElement)[];
+  label: string;
 }
 
 interface Props {
-  header?: React.ReactNode;
-  rows: InfoRow[];
-  separator?: boolean;
+  content?: InfoRow[];
 }
 
-export const renderRow = ({ label, content, separator }: InfoRowProps): React.ReactNode => {
-  if (content === undefined) return null;
+export const Row: React.FC<InfoRow> = ({ label, value }: InfoRow) => {
+  const valueArray = ensureArray(value);
   return (
-    <div className={[css.info, separator ? css.separator : null].join(' ')} key={label?.toString()}>
+    <div className={css.row}>
       <dt className={css.label}>{label}</dt>
-      {Array.isArray(content) ? (
-        <dd className={css.contentList}>
-          {content.map((item, idx) => (
-            <div className={css.content} key={idx}>
-              {item}
-            </div>
-          ))}
-        </dd>
-      ) : (
-        <dd className={css.content}>
-          {content === null || String(content).trim() === '' ? (
-            <code className={css.blank}> {content}</code>
-          ) : (
-            content
-          )}
-        </dd>
-      )}
+      <div className={css.valueList}>
+        {valueArray.map((item, idx) => (
+          <dd className={css.value} key={idx}>
+            {item}
+          </dd>
+        ))}
+      </div>
     </div>
   );
 };
 
-const Glossary: React.FC<Props> = ({ header, rows, separator = true }: Props) => {
+const Glossary: React.FC<Props> = ({ content = [] }: Props) => {
   return (
     <dl className={css.base}>
-      {header != null ? <div className={css.header}>{header}</div> : null}
-      {rows.map((row) => renderRow({ ...row, separator }))}
+      {content.map((row, idx) => (
+        <Row key={row.label + idx} label={row.label} value={row.value} />
+      ))}
     </dl>
   );
 };

--- a/src/kit/Glossary.tsx
+++ b/src/kit/Glossary.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+
+import css from './Glossary.module.scss';
+
+export interface InfoRow {
+  content?: React.ReactNode | React.ReactNode[];
+  label: React.ReactNode;
+}
+
+interface InfoRowProps extends InfoRow {
+  separator: boolean;
+}
+
+interface Props {
+  header?: React.ReactNode;
+  rows: InfoRow[];
+  separator?: boolean;
+}
+
+export const renderRow = ({ label, content, separator }: InfoRowProps): React.ReactNode => {
+  if (content === undefined) return null;
+  return (
+    <div className={[css.info, separator ? css.separator : null].join(' ')} key={label?.toString()}>
+      <dt className={css.label}>{label}</dt>
+      {Array.isArray(content) ? (
+        <dd className={css.contentList}>
+          {content.map((item, idx) => (
+            <div className={css.content} key={idx}>
+              {item}
+            </div>
+          ))}
+        </dd>
+      ) : (
+        <dd className={css.content}>
+          {content === null || String(content).trim() === '' ? (
+            <code className={css.blank}> {content}</code>
+          ) : (
+            content
+          )}
+        </dd>
+      )}
+    </div>
+  );
+};
+
+const Glossary: React.FC<Props> = ({ header, rows, separator = true }: Props) => {
+  return (
+    <dl className={css.base}>
+      {header != null ? <div className={css.header}>{header}</div> : null}
+      {rows.map((row) => renderRow({ ...row, separator }))}
+    </dl>
+  );
+};
+
+export default Glossary;

--- a/src/kit/internal/functions.ts
+++ b/src/kit/internal/functions.ts
@@ -547,3 +547,5 @@ export const rgba2hsl = (rgba: RgbaColor): HslColor => {
 export const hsl2str = (hsl: HslColor): string => {
   return `hsl(${hsl.h}, ${hsl.s}%, ${hsl.l}%)`;
 };
+
+export const ensureArray = <T>(data: T | T[]): T[] => (Array.isArray(data) ? data : [data]);


### PR DESCRIPTION
The Glossary component will serve as a replacement for/be used in the following components in the main repo:

-    InfoBox
-    MetadataCard
-    Json
-    ResourcePoolCard
-    `renderRow`/`renderResource` in CheckpointModal