### PR TITLE
Update LineChart internal xRange/zoom interactions

### DIFF
--- a/src/kit/LineChart.tsx
+++ b/src/kit/LineChart.tsx
@@ -26,7 +26,9 @@ const getScientificNotationTickValues: uPlot.Axis['values'] = (_self, rawValues)
   const useNotation = !!rawValues.find(
     (val) => val > 9_999 || val < -9_999 || (0 < val && val < 0.0001) || (-0.0001 < val && val < 0),
   );
-  return useNotation ? rawValues.map((val) => (val === 0 ? val : val.toExponential(2))) : rawValues;
+  return useNotation
+    ? rawValues.map((val) => (val === 0 ? val : val.toExponential(2)))
+    : rawValues.map((val) => Number(val.toFixed(2)));
 };
 
 /**
@@ -34,6 +36,7 @@ const getScientificNotationTickValues: uPlot.Axis['values'] = (_self, rawValues)
  * Config for a single LineChart component.
  * @param {number} [focusedSeries] - Highlight one Serie's line and fade the others, given an index in the given series.
  * @param {number} [height=350] - Height in pixels.
+ * @param {number} [key] - Fixed ID for changing chart div.
  * @param {Scale} [scale=Scale.Linear] - Linear or Log Scale for the y-axis.
  * @param {Serie[]} series - Array of valid series to plot onto the chart.
  * @param {boolean} [showLegend=false] - Display a custom legend below the chart with each series's color and name.
@@ -46,6 +49,7 @@ const getScientificNotationTickValues: uPlot.Axis['values'] = (_self, rawValues)
 interface ChartProps {
   focusedSeries?: number;
   height?: number;
+  key?: number;
   onPointClick?: (event: MouseEvent, point: UPlotPoint) => void;
   onPointFocus?: (point: UPlotPoint | undefined) => void;
   plugins?: Plugin[];
@@ -69,6 +73,7 @@ export const LineChart: React.FC<LineChartProps> = ({
   focusedSeries,
   handleError,
   height = 350,
+  key,
   onPointClick,
   onPointFocus,
   scale = Scale.Linear,
@@ -78,7 +83,7 @@ export const LineChart: React.FC<LineChartProps> = ({
   title,
   xAxis = XAxisDomain.Batches,
   xLabel,
-  xRange: unzoomedXRange,
+  xRange,
   yLabel,
   yTickValues = getScientificNotationTickValues,
 }: LineChartProps) => {
@@ -86,9 +91,6 @@ export const LineChart: React.FC<LineChartProps> = ({
   const isLoading = Loadable.isLoadable(propSeries) && Loadable.isNotLoaded(propSeries);
 
   const [hiddenSeries, setHiddenSeries] = useState<Record<number, boolean>>({});
-  const [xRange, setXRange] = useState<
-    Record<XAxisDomain, [number, number] | undefined> | undefined
-  >(unzoomedXRange);
 
   const hasPopulatedSeries: boolean = useMemo(
     () => !!series.find((serie) => serie.data[xAxis]?.length),
@@ -104,6 +106,14 @@ export const LineChart: React.FC<LineChartProps> = ({
     const xSet = new Set<number>();
     const yValues: Record<string, Record<string, number | null>> = {};
 
+    // add min and max of xRange
+    const xMin = xRange?.[xAxis]?.[0];
+    const xMax = xRange?.[xAxis]?.[1];
+    if (xMin !== undefined && xMax !== undefined) {
+      xSet.add(xMin);
+      xSet.add(xMax);
+    }
+
     series.forEach((serie, serieIndex) => {
       yValues[serieIndex] = {};
       if (hiddenSeries[serieIndex]) {
@@ -111,6 +121,9 @@ export const LineChart: React.FC<LineChartProps> = ({
       }
       (serie.data[xAxis] || []).forEach((pt) => {
         const xVal = pt[0];
+        if ((xMin !== undefined && xVal < xMin) || (xMax !== undefined && xVal > xMax)) {
+          return;
+        }
         xSet.add(xVal);
         yValues[serieIndex][xVal] = Number.isFinite(pt[1]) ? pt[1] : null;
       });
@@ -123,12 +136,13 @@ export const LineChart: React.FC<LineChartProps> = ({
     });
 
     return [xValues, ...yValuesArray];
-  }, [series, xAxis, hiddenSeries]);
+  }, [series, xAxis, hiddenSeries, xRange]);
 
   const xTickValues: uPlot.Axis.Values | undefined = useMemo(() => {
     if (xAxis === XAxisDomain.Time) {
-      const timeDelta = xRange?.[XAxisDomain.Time]
-        ? (xRange[XAxisDomain.Time]?.[1] || 0) - (xRange[XAxisDomain.Time]?.[0] || 0)
+      const timeRange = xRange?.[XAxisDomain.Time];
+      const timeDelta = timeRange
+        ? (timeRange[1] || 0) - (timeRange[0] || 0)
         : chartData[0][chartData[0].length - 1] - chartData[0][0];
       if (timeDelta < 43200) {
         // 12 hours
@@ -189,22 +203,20 @@ export const LineChart: React.FC<LineChartProps> = ({
         drag: { x: true, y: false },
       },
       height: height - (hasPopulatedSeries ? 0 : 20),
-      hooks: {
-        init: [
-          // allow xRange-d chart to zoom
-          (plot: uPlot) =>
-            xRange?.[xAxis] &&
-            plot.hooks.setSelect?.push(() => {
-              setXRange({ ...xRange, [xAxis]: undefined });
-            }),
-        ],
-      },
-      key: xRange?.[xAxis]?.[0],
+      key,
       legend: { show: false },
       plugins,
       scales: {
         x: {
-          range: xRange?.[xAxis],
+          range: (u, min, max) => {
+            const r: [number, number] = xRange?.[xAxis]
+              ? [
+                  Math.max(min, xRange?.[xAxis]?.[0] ?? min),
+                  Math.min(max, xRange?.[xAxis]?.[1] ?? max),
+                ]
+              : [min, max];
+            return r;
+          },
           time: xAxis === XAxisDomain.Time,
         },
         y: {
@@ -243,6 +255,7 @@ export const LineChart: React.FC<LineChartProps> = ({
     hasPopulatedSeries,
     propPlugins,
     focusedSeries,
+    key,
   ]);
 
   return (

--- a/src/kit/LineChart.tsx
+++ b/src/kit/LineChart.tsx
@@ -49,7 +49,7 @@ const getScientificNotationTickValues: uPlot.Axis['values'] = (_self, rawValues)
 interface ChartProps {
   focusedSeries?: number;
   height?: number;
-  key?: number;
+  key?: Options['key'];
   onPointClick?: (event: MouseEvent, point: UPlotPoint) => void;
   onPointFocus?: (point: UPlotPoint | undefined) => void;
   plugins?: Plugin[];

--- a/src/kit/LineChart.tsx
+++ b/src/kit/LineChart.tsx
@@ -208,7 +208,7 @@ export const LineChart: React.FC<LineChartProps> = ({
       plugins,
       scales: {
         x: {
-          range: (u, min, max) => {
+          range: (_, min, max) => {
             const r: [number, number] = xRange?.[xAxis]
               ? [
                   Math.max(min, xRange?.[xAxis]?.[0] ?? min),

--- a/src/kit/internal/functions.ts
+++ b/src/kit/internal/functions.ts
@@ -372,6 +372,12 @@ export const humanReadableNumber = (num: number, precision = DEFAULT_PRECISION):
     if (absoluteNum < 0.01 || absoluteNum > 999) {
       content = num.toExponential(Math.max(precision, 0));
     }
+  } else {
+    // big ints
+    const absoluteNum = Math.abs(num);
+    if (absoluteNum > 999) {
+      content = num.toExponential(Math.max(precision, 0));
+    }
   }
 
   return content;

--- a/src/kit/internal/functions.ts
+++ b/src/kit/internal/functions.ts
@@ -365,21 +365,16 @@ export const humanReadableNumber = (num: number, precision = DEFAULT_PRECISION):
     content = 'NaN';
   } else if (!Number.isFinite(num)) {
     content = `${num < 0 ? '-' : ''}Infinity`;
-  } else if (!Number.isInteger(num)) {
-    content = num.toFixed(Math.max(precision, 0));
+  } else {
+    if (!Number.isInteger(num)) {
+      content = num.toFixed(Math.max(precision, 0));
+    }
 
     const absoluteNum = Math.abs(num);
     if (absoluteNum < 0.01 || absoluteNum > 999) {
       content = num.toExponential(Math.max(precision, 0));
     }
-  } else {
-    // big ints
-    const absoluteNum = Math.abs(num);
-    if (absoluteNum > 999) {
-      content = num.toExponential(Math.max(precision, 0));
-    }
   }
-
   return content;
 };
 

--- a/src/kit/internal/functions.ts
+++ b/src/kit/internal/functions.ts
@@ -366,13 +366,11 @@ export const humanReadableNumber = (num: number, precision = DEFAULT_PRECISION):
   } else if (!Number.isFinite(num)) {
     content = `${num < 0 ? '-' : ''}Infinity`;
   } else {
-    if (!Number.isInteger(num)) {
-      content = num.toFixed(Math.max(precision, 0));
-    }
-
     const absoluteNum = Math.abs(num);
     if (absoluteNum < 0.01 || absoluteNum > 999) {
       content = num.toExponential(Math.max(precision, 0));
+    } else if (!Number.isInteger(num)) {
+      content = num.toFixed(Math.max(precision, 0));
     }
   }
   return content;


### PR DESCRIPTION
**Scientific notation**
If yAxis tick label decimals are not small enough for scientific notation, the value (0.3000004 observed) will pass through `.toFixed(2)`

Very large integers will be shown in scientific notation in the **tooltip**. This can be checked in the scientific notation example on the DesignKit page

**React behavior**
Parent component can pass `key` prop to the chart

**Zoom interactions**
We want a fixed `xRange` which is still responsive to zoom or changing the start and end of the range
Methods used:
- add [xMin, null], [xMax, null] to each series
- uPlot's `xRange` is set to a function. When the user zooms, a new min and max are passed into the function