### PR TITLE
feat: add TabsProps as export from the Pivot component

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ export { default as DocumentCard } from 'kit/DocumentCard';
 export { default as DocumentCards } from 'kit/DocumentCards';
 export { default as Pagination } from 'kit/Pagination';
 export { default as Pivot } from 'kit/Pivot';
-export type { TabItem } from 'kit/Pivot';
+export type { PivotProps } from 'kit/Pivot';
 export { default as RadioGroup } from 'kit/RadioGroup';
 export type { RadioGroupOption } from 'kit/RadioGroup';
 export { default as Section } from 'kit/Section';

--- a/src/kit/Pivot.tsx
+++ b/src/kit/Pivot.tsx
@@ -3,7 +3,7 @@ import React, { KeyboardEvent, MouseEvent, ReactNode } from 'react';
 
 import css from './Pivot.module.scss';
 
-export type TabItem = {
+type TabItem = {
   children?: ReactNode;
   forceRender?: boolean;
   key: string;
@@ -12,7 +12,7 @@ export type TabItem = {
 
 export type PivotTabType = 'primary' | 'secondary';
 
-interface Props {
+export interface PivotProps {
   activeKey?: string;
   defaultActiveKey?: string;
   destroyInactiveTabPane?: boolean;
@@ -34,7 +34,7 @@ const convertTabType = (type: PivotTabType): TabsProps['type'] => {
   }
 };
 
-const Pivot: React.FC<Props> = ({ type = 'primary', ...props }) => {
+const Pivot: React.FC<PivotProps> = ({ type = 'primary', ...props }) => {
   const tabType = convertTabType(type);
 
   return <Tabs className={css.base} type={tabType} {...props} />;

--- a/src/kit/internal/Markdown.tsx
+++ b/src/kit/internal/Markdown.tsx
@@ -2,7 +2,7 @@ import { default as MarkdownViewer } from 'markdown-to-jsx';
 import React, { useMemo } from 'react';
 
 import useResize from 'kit/internal/useResize';
-import Pivot, { TabItem } from 'kit/Pivot';
+import Pivot, { PivotProps } from 'kit/Pivot';
 import Spinner from 'kit/Spinner';
 
 import css from './Markdown.module.scss';
@@ -49,7 +49,7 @@ const Markdown: React.FC<Props> = ({
   onClick,
 }: Props) => {
   const { size } = useResize();
-  const tabItems: TabItem[] = useMemo(() => {
+  const tabItems: PivotProps['items'] = useMemo(() => {
     return [
       {
         children: (


### PR DESCRIPTION
## Description

Tickets: WEB-1721

add TabsProps as export from the Pivot component.

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->
