### PR TITLE
fix: Modal left and right clicks do not propagate to source (redo of #34)

### DIFF
--- a/src/kit/Modal.module.scss
+++ b/src/kit/Modal.module.scss
@@ -58,3 +58,7 @@
     }
   }
 }
+.wrapper {
+  height: 0;
+  width: 0;
+}

--- a/src/kit/Modal.tsx
+++ b/src/kit/Modal.tsx
@@ -110,58 +110,67 @@ export const Modal: React.FC<ModalProps> = ({
     }
   }, [submit, setIsOpen]);
 
+  const stopEventPropagation = (e) => e.stopPropagation();
+
   return (
-    <AntdModal
-      cancelText={cancelText}
-      className={classes.join(' ')}
-      closeIcon={<Icon name="close" size="small" title="Close modal" />}
-      footer={
-        <div className={css.footer}>
-          <div className={css.footerLink}>{footerLink}</div>
-          <div className={css.buttons}>
-            {(cancel || cancelText) && (
-              <Button key="back" onClick={close}>
-                {cancelText || DEFAULT_CANCEL_LABEL}
+    <div
+      className={css.wrapper}
+      onClick={stopEventPropagation}
+      onContextMenu={stopEventPropagation}>
+      <AntdModal
+        cancelText={cancelText}
+        className={classes.join(' ')}
+        closeIcon={<Icon name="close" size="small" title="Close modal" />}
+        footer={
+          <div className={css.footer}>
+            <div className={css.footerLink}>{footerLink}</div>
+            <div className={css.buttons}>
+              {(cancel || cancelText) && (
+                <Button key="back" onClick={close}>
+                  {cancelText || DEFAULT_CANCEL_LABEL}
+                </Button>
+              )}
+              <Button
+                danger={danger}
+                disabled={!!submit?.disabled}
+                form={submit?.form}
+                htmlType={submit?.form ? 'submit' : 'button'}
+                key="submit"
+                loading={isSubmitting}
+                tooltip={
+                  submit?.disabled ? 'Address validation errors before proceeding' : undefined
+                }
+                type="primary"
+                onClick={handleSubmit}>
+                {submit?.text ?? 'OK'}
               </Button>
-            )}
-            <Button
-              danger={danger}
-              disabled={!!submit?.disabled}
-              form={submit?.form}
-              htmlType={submit?.form ? 'submit' : 'button'}
-              key="submit"
-              loading={isSubmitting}
-              tooltip={submit?.disabled ? 'Address validation errors before proceeding' : undefined}
-              type="primary"
-              onClick={handleSubmit}>
-              {submit?.text ?? 'OK'}
-            </Button>
-          </div>
-        </div>
-      }
-      key={key}
-      maskClosable={true}
-      open={isOpen}
-      title={
-        <div className={css.header}>
-          {danger ? (
-            <div className={css.dangerIcon}>
-              <Icon name="warning" size="large" title="Danger" />
             </div>
-          ) : (
-            icon && <Icon decorative name={icon} size="large" />
-          )}
-          <div className={css.headerTitle}>{title}</div>
-          <div className={css.headerLink}>{headerLink}</div>
-        </div>
-      }
-      width={modalWidths[size]}
-      onCancel={close}
-      onOk={handleSubmit}>
-      <Spinner spinning={isSubmitting}>
-        <div className={css.modalBody}>{modalBody}</div>
-      </Spinner>
-    </AntdModal>
+          </div>
+        }
+        key={key}
+        maskClosable={true}
+        open={isOpen}
+        title={
+          <div className={css.header}>
+            {danger ? (
+              <div className={css.dangerIcon}>
+                <Icon name="warning" size="large" title="Danger" />
+              </div>
+            ) : (
+              icon && <Icon decorative name={icon} size="large" />
+            )}
+            <div className={css.headerTitle}>{title}</div>
+            <div className={css.headerLink}>{headerLink}</div>
+          </div>
+        }
+        width={modalWidths[size]}
+        onCancel={close}
+        onOk={handleSubmit}>
+        <Spinner spinning={isSubmitting}>
+          <div className={css.modalBody}>{modalBody}</div>
+        </Spinner>
+      </AntdModal>
+    </div>
   );
 };
 

--- a/src/kit/Modal.tsx
+++ b/src/kit/Modal.tsx
@@ -15,6 +15,7 @@ import Spinner from 'kit/Spinner';
 import { useTheme } from 'kit/Theme';
 import { ErrorHandler, ErrorLevel, ErrorType } from 'kit/utils/error';
 
+import { type AnyMouseEvent } from './internal/types';
 import css from './Modal.module.scss';
 
 export type ModalSize = 'small' | 'medium' | 'large';
@@ -110,7 +111,7 @@ export const Modal: React.FC<ModalProps> = ({
     }
   }, [submit, setIsOpen]);
 
-  const stopEventPropagation = (e) => e.stopPropagation();
+  const stopEventPropagation = (e: AnyMouseEvent) => e.stopPropagation();
 
   return (
     <div


### PR DESCRIPTION
Mostly repeats #34 placing the Modal component inside of a wrapper div.

Now prevents left AND right clicks from propagating their events up to the parent. Allows modal components to be placed inside a clickable row or card.

Expects this PR in the main repo, changing from `<><Card>...</Card>{contextHolders}</>` in a Workspace/Project card to `<Card>...{contextHolders}</Card>`: https://github.com/determined-ai/determined/pull/8378