### PR TITLE
feat: add alignment option to Glossary

### DIFF
--- a/src/DesignKit.tsx
+++ b/src/DesignKit.tsx
@@ -2985,11 +2985,23 @@ const GlossarySection: React.FC = () => {
         </p>
       </AntDCard>
       <AntDCard title="Usage">
+        <strong>Align values left (default)</strong>
         <Glossary
           content={[
             { label: 'Key', value: 'Value' },
             { label: 'Multiple Values', value: ['Value 1', 'Value 2', 'Value 3'] },
             { label: 'Component Value', value: <Surface>Arbitrary component</Surface> },
+            { label: "Value Shouldn't Overflow", value: loremIpsum.split(' ').join('') },
+          ]}
+        />
+        <strong>Align values right</strong>
+        <Glossary
+          alignValues="right"
+          content={[
+            { label: 'Key', value: 'Value' },
+            { label: 'Multiple Values', value: ['Value 1', 'Value 2', 'Value 3'] },
+            { label: 'Component Value', value: <Surface>Arbitrary component</Surface> },
+            { label: "Value Shouldn't Overflow", value: loremIpsum.split(' ').join('') },
           ]}
         />
       </AntDCard>

--- a/src/DesignKit.tsx
+++ b/src/DesignKit.tsx
@@ -3004,7 +3004,9 @@ const GlossarySection: React.FC = () => {
             {
               label: "Don't align text inside component value",
               value: (
-                <div style={{ border: '1px solid black', width: 400 }}>Arbitrary component</div>
+                <Surface>
+                  <div style={{ width: 400 }}>Arbitrary component</div>
+                </Surface>
               ),
             },
             { label: "Value shouldn't overflow", value: loremIpsum.split(' ').join('') },

--- a/src/DesignKit.tsx
+++ b/src/DesignKit.tsx
@@ -2989,9 +2989,9 @@ const GlossarySection: React.FC = () => {
         <Glossary
           content={[
             { label: 'Key', value: 'Value' },
-            { label: 'Multiple Values', value: ['Value 1', 'Value 2', 'Value 3'] },
-            { label: 'Component Value', value: <Surface>Arbitrary component</Surface> },
-            { label: "Value Shouldn't Overflow", value: loremIpsum.split(' ').join('') },
+            { label: 'Multiple values', value: ['Value 1', 'Value 2', 'Value 3'] },
+            { label: 'Component value', value: <Surface>Arbitrary component</Surface> },
+            { label: "Value shouldn't overflow", value: loremIpsum.split(' ').join('') },
           ]}
         />
         <strong>Align values right</strong>
@@ -2999,9 +2999,15 @@ const GlossarySection: React.FC = () => {
           alignValues="right"
           content={[
             { label: 'Key', value: 'Value' },
-            { label: 'Multiple Values', value: ['Value 1', 'Value 2', 'Value 3'] },
-            { label: 'Component Value', value: <Surface>Arbitrary component</Surface> },
-            { label: "Value Shouldn't Overflow", value: loremIpsum.split(' ').join('') },
+            { label: 'Multiple values', value: ['Value 1', 'Value 2', 'Value 3'] },
+            { label: 'Component value', value: <Surface>Arbitrary component</Surface> },
+            {
+              label: "Don't align text inside component value",
+              value: (
+                <div style={{ border: '1px solid black', width: 400 }}>Arbitrary component</div>
+              ),
+            },
+            { label: "Value shouldn't overflow", value: loremIpsum.split(' ').join('') },
           ]}
         />
       </AntDCard>

--- a/src/kit/Glossary.module.scss
+++ b/src/kit/Glossary.module.scss
@@ -25,6 +25,10 @@
       .value {
         margin: 0;
         min-width: 0;
+
+        .componentWrapper {
+          text-align: initial;
+        }
       }
     }
   }

--- a/src/kit/Glossary.module.scss
+++ b/src/kit/Glossary.module.scss
@@ -1,8 +1,4 @@
 .base {
-  color: var(--theme-surface-on);
-  font-size: 16px;
-  margin: 0;
-
   .row {
     align-items: center;
     display: flex;
@@ -20,7 +16,6 @@
       display: flex;
       flex: 1 66%;
       flex-direction: column;
-      font-size: 14px;
 
       .value {
         margin: 0;

--- a/src/kit/Glossary.module.scss
+++ b/src/kit/Glossary.module.scss
@@ -11,14 +11,15 @@
     .label {
       align-self: flex-start;
       flex: 0 0 34%;
-      font-size: 12px;
       margin-right: 20px;
       max-width: 200px;
       min-width: 50px;
       padding-right: 8px;
     }
     .valueList {
+      display: flex;
       flex: 1 66%;
+      flex-direction: column;
       font-size: 14px;
 
       .value {
@@ -26,5 +27,13 @@
         min-width: 0;
       }
     }
+  }
+  &.align-left .row .valueList {
+    align-items: flex-start;
+    text-align: start;
+  }
+  &.align-right .row .valueList {
+    align-items: flex-end;
+    text-align: end;
   }
 }

--- a/src/kit/Glossary.tsx
+++ b/src/kit/Glossary.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
 import { useTheme } from 'kit/Theme';
+import { Body, Label } from 'kit/Typography';
 
 import css from './Glossary.module.scss';
-import { ensureArray } from './internal/functions';
+import { ensureArray, isString } from './internal/functions';
 export interface InfoRow {
   value: string | React.ReactElement | (string | React.ReactElement)[];
   label: string;
@@ -11,17 +12,20 @@ export interface InfoRow {
 
 interface Props {
   content?: InfoRow[];
+  alignValues?: 'left' | 'right';
 }
 
 export const Row: React.FC<InfoRow> = ({ label, value }: InfoRow) => {
   const valueArray = ensureArray(value);
   return (
     <div className={css.row}>
-      <dt className={css.label}>{label}</dt>
+      <dt className={css.label}>
+        <Label size="default">{label}</Label>
+      </dt>
       <div className={css.valueList}>
         {valueArray.map((item, idx) => (
           <dd className={css.value} key={idx}>
-            {item}
+            {isString(item) ? <Body>{item}</Body> : item}
           </dd>
         ))}
       </div>
@@ -29,11 +33,11 @@ export const Row: React.FC<InfoRow> = ({ label, value }: InfoRow) => {
   );
 };
 
-const Glossary: React.FC<Props> = ({ content = [] }: Props) => {
+const Glossary: React.FC<Props> = ({ content = [], alignValues = 'left' }: Props) => {
   const {
     themeSettings: { className: themeClass },
   } = useTheme();
-  const classes = [css.base, themeClass];
+  const classes = [css.base, themeClass, css[`align-${alignValues}`]];
   return (
     <dl className={classes.join(' ')}>
       {content.map((row, idx) => (

--- a/src/kit/Glossary.tsx
+++ b/src/kit/Glossary.tsx
@@ -25,7 +25,11 @@ export const Row: React.FC<InfoRow> = ({ label, value }: InfoRow) => {
       <div className={css.valueList}>
         {valueArray.map((item, idx) => (
           <dd className={css.value} key={idx}>
-            {isString(item) ? <Body>{item}</Body> : item}
+            {isString(item) ? (
+              <Body>{item}</Body>
+            ) : (
+              <div className={css.componentWrapper}>{item}</div>
+            )}
           </dd>
         ))}
       </div>


### PR DESCRIPTION
Allows Glossary values to be aligned left or right. Also fixes overflow bug.

![Screenshot 2023-11-13 at 09-44-24 Standalone Design Kit](https://github.com/determined-ai/hew/assets/15078396/c1cbb540-4755-42e3-9173-e4b2121d7dee)
