### PR TITLE
chore: Fix typo in Select placeholder

### DIFF
--- a/src/DesignKit.tsx
+++ b/src/DesignKit.tsx
@@ -70,7 +70,7 @@ import loremIpsum, { loremIpsumSentence } from 'utils/loremIpsum';
 import css from './DesignKit.module.scss';
 import ThemeToggle from './ThemeToggle';
 
-const noOp = () => {};
+const noOp = () => { };
 
 const ComponentTitles = {
   Accordion: 'Accordion',
@@ -532,7 +532,7 @@ const SelectSection: React.FC = () => {
             { label: 'Option 2', value: 2 },
             { label: 'Option 3', value: 3 },
           ]}
-          placeholder="Nonsearcahble Select"
+          placeholder="Non-searchable Select"
           searchable={false}
         />
         <strong>Multiple Select with tags</strong>

--- a/src/DesignKit.tsx
+++ b/src/DesignKit.tsx
@@ -70,7 +70,7 @@ import loremIpsum, { loremIpsumSentence } from 'utils/loremIpsum';
 import css from './DesignKit.module.scss';
 import ThemeToggle from './ThemeToggle';
 
-const noOp = () => { };
+const noOp = () => {};
 
 const ComponentTitles = {
   Accordion: 'Accordion',


### PR DESCRIPTION
Fixes a typo in the "Select without search" placeholder on the DesignKit page: 

Current:
<img width="198" alt="Screen Shot 2023-11-13 at 4 14 30 PM" src="https://github.com/determined-ai/hew/assets/103522725/8a3d873b-2814-4753-8654-d669541bb3be">

Updated:
<img width="200" alt="Screen Shot 2023-11-13 at 4 15 51 PM" src="https://github.com/determined-ai/hew/assets/103522725/60c5b680-e50f-4086-ac68-6af1f35d6cab">


