### PR TITLE
chore: Add eslint rule for ?? expressions [WEB-1804]

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -97,6 +97,7 @@ module.exports = {
     ],
     'keyword-spacing': ['error'],
     'no-console': ['error', { allow: ['error'] }],
+    'no-constant-binary-expression': 'error',
     'no-duplicate-imports': 'error',
     'no-empty': ['error', { allowEmptyCatch: false }],
     'no-multi-spaces': ['error', { ignoreEOLComments: true }],


### PR DESCRIPTION
Adding eslint rule described in https://eslint.org/blog/2022/07/interesting-bugs-caught-by-no-constant-binary-expression/

Errors code with the operator `A ?? B` where A is a constant non-null type and B is never returned

No changes in this repo, but trying to keep eslint consistent with the change in https://github.com/determined-ai/determined/pull/8410