### PR TITLE
fix: Patch modal CSS / handling in document flow

### DIFF
--- a/src/kit/Modal.module.scss
+++ b/src/kit/Modal.module.scss
@@ -59,6 +59,5 @@
   }
 }
 .wrapper {
-  height: 0;
-  width: 0;
+  display: none;
 }


### PR DESCRIPTION
Fixes an issue where the Modal event-handler / wrapper div was interfering with WorkspaceCard and other expected layouts

Adding `display: none` will not affect visibility of the Modal, or the event handling.