### PR TITLE
fix: Incorrect font in Dropdown Component [WEB-1821]

### DIFF
--- a/src/kit/Dropdown.tsx
+++ b/src/kit/Dropdown.tsx
@@ -114,6 +114,7 @@ const Dropdown: React.FC<PropsWithChildren<Props>> = ({
       disabled={disabled}
       menu={antdMenu}
       open={open}
+      overlayClassName={themeClass}
       overlayStyle={overlayStyle}
       placement={placement}
       trigger={[isContextMenu ? 'contextMenu' : 'click']}


### PR DESCRIPTION
The overlay for the dropdown component in Hew is missing the needed `themeClass`. To test verify that the "Dropdown" menu now has the correct font style. 


Current:
![Screen Shot 2023-11-14 at 5 21 13 PM](https://github.com/determined-ai/hew/assets/103522725/dd5ed276-b764-4511-b4e1-f609f2593893)

Updated:
![Screen Shot 2023-11-14 at 5 21 38 PM](https://github.com/determined-ai/hew/assets/103522725/6bbf2791-5357-4bdf-8623-b6dc7466e567)

