### PR TITLE
fix: Logs filter bar is partially hidden

### DIFF
--- a/src/kit/LogViewer/LogViewer.module.scss
+++ b/src/kit/LogViewer/LogViewer.module.scss
@@ -54,13 +54,4 @@
   border-bottom: var(--theme-stroke-width) solid var(--theme-stage-border);
   margin-bottom: 8px;
   padding: 8px 8px 8px 0;
-
-  h3 {
-    height: 32px;
-    line-height: 32px;
-    margin-bottom: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
 }

--- a/src/kit/LogViewer/LogViewer.tsx
+++ b/src/kit/LogViewer/LogViewer.tsx
@@ -534,9 +534,7 @@ const LogViewer: React.FC<Props> = ({
     <Section>
       <div className={css.options}>
         <Row>
-          <Column>
-            <h3>{props.title}</h3>
-          </Column>
+          <Column>{props.title}</Column>
           <Column align="right">
             <Space>
               <ClipboardButton


### PR DESCRIPTION
Before: 
<img width="808" alt="Screenshot 2023-11-14 at 6 03 28 PM" src="https://github.com/determined-ai/hew/assets/40620519/2d355254-dc30-4e2e-93c3-57e052528f64">

After:
<img width="1014" alt="Screenshot 2023-11-14 at 6 03 50 PM" src="https://github.com/determined-ai/hew/assets/40620519/1dbe3ceb-6645-46ff-9a0a-ef7eca09aa85">

Ticket: [WEB-1805](https://hpe-aiatscale.atlassian.net/browse/WEB-1805)

[WEB-1805]: https://hpe-aiatscale.atlassian.net/browse/WEB-1805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ