### PR TITLE
fix: Datepicker styling [WEB-1836]

### DIFF
--- a/src/kit/DatePicker.tsx
+++ b/src/kit/DatePicker.tsx
@@ -21,14 +21,15 @@ interface DatePickerProps {
 }
 
 const DatePicker: React.FC<DatePickerProps> = ({ label, ...props }) => {
-  const composedProps = {
-    ...props,
-    style: { minWidth: props.width },
-    width: undefined,
-  };
   const {
     themeSettings: { className: themeClass },
   } = useTheme();
+  const composedProps = {
+    ...props,
+    popupClassName: themeClass,
+    style: { minWidth: props.width },
+    width: undefined,
+  };
   const classes = [css.base, themeClass];
   return (
     <div className={classes.join(' ')}>


### PR DESCRIPTION
The Datepicker popup currently does not have the correct theming. This PR adds the correct classname to the popup. 

Current:
![Screen Shot 2023-11-16 at 2 20 45 PM](https://github.com/determined-ai/hew/assets/103522725/62286575-2330-4686-af2b-26fbe172553e)

Updated:
![Screen Shot 2023-11-16 at 2 20 56 PM](https://github.com/determined-ai/hew/assets/103522725/b0ece996-119e-4753-a283-eb9b4c52ef97)

[Ticket](https://hpe-aiatscale.atlassian.net/browse/WEB-1836)

Testing:
- Ensure that the Datepicker popup font and theme matches the rest of the application. 