### PR TITLE
fix: InputNumber should apply passed in classnames [WEB-1837]

### DIFF
--- a/src/kit/InputNumber.tsx
+++ b/src/kit/InputNumber.tsx
@@ -21,9 +21,9 @@ const InputNumber: React.FC<InputNumberProps> = forwardRef(
   ({ ...props }: InputNumberProps, ref: React.ForwardedRef<HTMLInputElement>) => {
     const { onFocus, onBlur, inputRef } = useInputNumberEscape(ref);
     const {
-      themeSettings: { className },
+      themeSettings: { className: themeClass },
     } = useTheme();
-    const classes = props?.className ? className.concat(' ', props.className) : className;
+    const classes = props?.className ? themeClass.concat(' ', props.className) : themeClass;
     return (
       <AntdInputNumber
         {...props}

--- a/src/kit/InputNumber.tsx
+++ b/src/kit/InputNumber.tsx
@@ -21,12 +21,13 @@ const InputNumber: React.FC<InputNumberProps> = forwardRef(
   ({ ...props }: InputNumberProps, ref: React.ForwardedRef<HTMLInputElement>) => {
     const { onFocus, onBlur, inputRef } = useInputNumberEscape(ref);
     const {
-      themeSettings: { className: themeClass },
+      themeSettings: { className },
     } = useTheme();
+    const classes = props?.className ? className.concat(' ', props.className) : className;
     return (
       <AntdInputNumber
         {...props}
-        className={themeClass}
+        className={classes}
         ref={inputRef}
         onBlur={onBlur}
         onFocus={onFocus}


### PR DESCRIPTION
Relates to: https://hpe-aiatscale.slack.com/archives/CKQ3EV0G6/p1700001806966529

Currently the `InputNumber` does not respect passed in classNames. This fixes the issue. 

[Ticket](https://hpe-aiatscale.atlassian.net/browse/WEB-1837)