### PR TITLE
feat: add Elevation to Pivot (and extract Elevation from Surface) [WEB-1810]

### DIFF
--- a/src/DesignKit.tsx
+++ b/src/DesignKit.tsx
@@ -1948,7 +1948,7 @@ const SurfaceSection: React.FC = () => {
             </Surface>
           ))}
         </Space>
-        <strong>Nested borders increase elevation</strong>
+        <strong>Nested surfaces increase elevation</strong>
         <Surface>
           <Surface>
             <Surface>

--- a/src/DesignKit.tsx
+++ b/src/DesignKit.tsx
@@ -2151,6 +2151,7 @@ const PivotSection: React.FC = () => {
             type="secondary"
             onChange={onChangeTab}
           />
+          <p>The active tab and body have elevation applied.</p>
           <Surface>
             <Pivot
               items={[

--- a/src/DesignKit.tsx
+++ b/src/DesignKit.tsx
@@ -47,7 +47,7 @@ import Section from 'kit/Section';
 import Select, { Option } from 'kit/Select';
 import Spinner from 'kit/Spinner';
 import Surface from 'kit/Surface';
-import UIProvider, { DefaultTheme, Elevation, ShirtSize, Theme, useTheme } from 'kit/Theme';
+import UIProvider, { DefaultTheme, ElevationLevels, ShirtSize, Theme, useTheme } from 'kit/Theme';
 import { themeBase } from 'kit/Theme/themeUtils';
 import { useToast } from 'kit/Toast';
 import Toggle from 'kit/Toggle';
@@ -1917,7 +1917,7 @@ const AvatarSection: React.FC = () => {
 };
 
 const SurfaceSection: React.FC = () => {
-  const elevations: Elevation[] = [0, 1, 2, 3, 4];
+  const elevations: ElevationLevels[] = [0, 1, 2, 3, 4];
   return (
     <ComponentSection id="Surface">
       <AntDCard>
@@ -2136,7 +2136,7 @@ const PivotSection: React.FC = () => {
         <hr />
         <br />
         <strong>Secondary Pivot</strong>
-        <div>
+        <Column>
           <Pivot
             activeKey={activeKey}
             items={[
@@ -2151,7 +2151,21 @@ const PivotSection: React.FC = () => {
             type="secondary"
             onChange={onChangeTab}
           />
-        </div>
+          <Surface>
+            <Pivot
+              items={[
+                { children: 'Overview', key: 'Overview', label: 'Overview' },
+                { children: 'Hyperparameters', key: 'hyperparameters', label: 'Hyperparameters' },
+                { children: 'Checkpoints', key: 'checkpoints', label: 'Checkpoints' },
+                { children: 'Code', key: 'code', label: 'Code' },
+                { children: 'Notes', key: 'notes', label: 'Notes' },
+                { children: 'Profiler', key: 'profiler', label: 'Profiler' },
+                { children: 'Logs', key: 'logs', label: 'Logs' },
+              ]}
+              type="secondary"
+            />
+          </Surface>
+        </Column>
       </AntDCard>
     </ComponentSection>
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ export { default as Select, Option } from 'kit/Select';
 export { default as Spinner } from 'kit/Spinner';
 export { default as UIProvider } from 'kit/Theme';
 export { default as useUI } from 'kit/Theme';
-export type { Elevation } from 'kit/Theme';
+export type { ElevationLevels as Elevation } from 'kit/Theme';
 export { makeToast } from 'kit/Toast';
 export { default as Toggle } from 'kit/Toggle';
 export { default as Tooltip } from 'kit/Tooltip';

--- a/src/kit/Pivot.module.scss
+++ b/src/kit/Pivot.module.scss
@@ -4,7 +4,7 @@
 /* Tabs */
 
 .base {
-  &.e0 {
+  &.zero {
     &:global(
         .ant-tabs-card > .ant-tabs-nav > .ant-tabs-nav-wrap .ant-tabs-tab.ant-tabs-tab-active
       ) {
@@ -14,7 +14,7 @@
       @include e.elevation(0);
     }
   }
-  &.e1 {
+  &.one {
     &:global(
         .ant-tabs-card > .ant-tabs-nav > .ant-tabs-nav-wrap .ant-tabs-tab.ant-tabs-tab-active
       ) {
@@ -24,7 +24,7 @@
       @include e.elevation(1);
     }
   }
-  &.e2 {
+  &.two {
     &:global(
         .ant-tabs-card > .ant-tabs-nav > .ant-tabs-nav-wrap .ant-tabs-tab.ant-tabs-tab-active
       ) {
@@ -34,7 +34,7 @@
       @include e.elevation(2);
     }
   }
-  &.e3 {
+  &.three {
     &:global(
         .ant-tabs-card > .ant-tabs-nav > .ant-tabs-nav-wrap .ant-tabs-tab.ant-tabs-tab-active
       ) {
@@ -44,7 +44,7 @@
       @include e.elevation(3);
     }
   }
-  &.e4 {
+  &.four {
     &:global(
         .ant-tabs-card > .ant-tabs-nav > .ant-tabs-nav-wrap .ant-tabs-tab.ant-tabs-tab-active
       ) {

--- a/src/kit/Pivot.module.scss
+++ b/src/kit/Pivot.module.scss
@@ -1,8 +1,59 @@
 /* stylelint-disable no-descending-specificity */
+@use 'internal/Elevation.module.scss' as e;
 
 /* Tabs */
 
 .base {
+  &.e0 {
+    &:global(
+        .ant-tabs-card > .ant-tabs-nav > .ant-tabs-nav-wrap .ant-tabs-tab.ant-tabs-tab-active
+      ) {
+      @include e.elevation(0);
+    }
+    &:global(.ant-tabs-card > .ant-tabs-content-holder) {
+      @include e.elevation(0);
+    }
+  }
+  &.e1 {
+    &:global(
+        .ant-tabs-card > .ant-tabs-nav > .ant-tabs-nav-wrap .ant-tabs-tab.ant-tabs-tab-active
+      ) {
+      @include e.elevation(1);
+    }
+    &:global(.ant-tabs-card > .ant-tabs-content-holder) {
+      @include e.elevation(1);
+    }
+  }
+  &.e2 {
+    &:global(
+        .ant-tabs-card > .ant-tabs-nav > .ant-tabs-nav-wrap .ant-tabs-tab.ant-tabs-tab-active
+      ) {
+      @include e.elevation(2);
+    }
+    &:global(.ant-tabs-card > .ant-tabs-content-holder) {
+      @include e.elevation(2);
+    }
+  }
+  &.e3 {
+    &:global(
+        .ant-tabs-card > .ant-tabs-nav > .ant-tabs-nav-wrap .ant-tabs-tab.ant-tabs-tab-active
+      ) {
+      @include e.elevation(3);
+    }
+    &:global(.ant-tabs-card > .ant-tabs-content-holder) {
+      @include e.elevation(3);
+    }
+  }
+  &.e4 {
+    &:global(
+        .ant-tabs-card > .ant-tabs-nav > .ant-tabs-nav-wrap .ant-tabs-tab.ant-tabs-tab-active
+      ) {
+      @include e.elevation(4);
+    }
+    &:global(.ant-tabs-card > .ant-tabs-content-holder) {
+      @include e.elevation(4);
+    }
+  }
   &:global(.ant-tabs) {
     height: 100%;
   }
@@ -27,21 +78,20 @@
   &:global(.ant-tabs-card > .ant-tabs-nav > .ant-tabs-nav-wrap .ant-tabs-tab) {
     background-color: var(--theme-surface-strong);
     border-color: var(--theme-surface-border);
+    border-radius: var(--theme-border-radius) var(--theme-border-radius) 0 0;
   }
   &:global(.ant-tabs-card > .ant-tabs-nav > .ant-tabs-nav-wrap .ant-tabs-tab:hover) {
     background-color: var(--theme-surface);
     color: var(--theme-surface-on);
   }
-  &:global(.ant-tabs-card > .ant-tabs-nav > .ant-tabs-nav-wrap .ant-tabs-tab-active) {
-    background-color: var(--theme-surface);
-    border-bottom-color: var(--theme-surface);
+  &:global(.ant-tabs-card > .ant-tabs-nav > .ant-tabs-nav-wrap .ant-tabs-tab.ant-tabs-tab-active) {
+    border-bottom-color: transparent !important;
   }
   &:global(.ant-tabs-card > .ant-tabs-nav) {
     margin: 0;
   }
   &:global(.ant-tabs-card > .ant-tabs-content-holder) {
-    background-color: var(--theme-surface);
-    border-color: var(--theme-surface-border);
+    border-radius: 0 0 var(--theme-border-radius) var(--theme-border-radius);
     border-style: solid;
     border-width: 0 var(--theme-stroke-width) var(--theme-stroke-width) var(--theme-stroke-width);
   }

--- a/src/kit/Pivot.module.scss
+++ b/src/kit/Pivot.module.scss
@@ -4,56 +4,6 @@
 /* Tabs */
 
 .base {
-  &.zero {
-    &:global(
-        .ant-tabs-card > .ant-tabs-nav > .ant-tabs-nav-wrap .ant-tabs-tab.ant-tabs-tab-active
-      ) {
-      @include e.elevation(0);
-    }
-    &:global(.ant-tabs-card > .ant-tabs-content-holder) {
-      @include e.elevation(0);
-    }
-  }
-  &.one {
-    &:global(
-        .ant-tabs-card > .ant-tabs-nav > .ant-tabs-nav-wrap .ant-tabs-tab.ant-tabs-tab-active
-      ) {
-      @include e.elevation(1);
-    }
-    &:global(.ant-tabs-card > .ant-tabs-content-holder) {
-      @include e.elevation(1);
-    }
-  }
-  &.two {
-    &:global(
-        .ant-tabs-card > .ant-tabs-nav > .ant-tabs-nav-wrap .ant-tabs-tab.ant-tabs-tab-active
-      ) {
-      @include e.elevation(2);
-    }
-    &:global(.ant-tabs-card > .ant-tabs-content-holder) {
-      @include e.elevation(2);
-    }
-  }
-  &.three {
-    &:global(
-        .ant-tabs-card > .ant-tabs-nav > .ant-tabs-nav-wrap .ant-tabs-tab.ant-tabs-tab-active
-      ) {
-      @include e.elevation(3);
-    }
-    &:global(.ant-tabs-card > .ant-tabs-content-holder) {
-      @include e.elevation(3);
-    }
-  }
-  &.four {
-    &:global(
-        .ant-tabs-card > .ant-tabs-nav > .ant-tabs-nav-wrap .ant-tabs-tab.ant-tabs-tab-active
-      ) {
-      @include e.elevation(4);
-    }
-    &:global(.ant-tabs-card > .ant-tabs-content-holder) {
-      @include e.elevation(4);
-    }
-  }
   &:global(.ant-tabs) {
     height: 100%;
   }
@@ -86,6 +36,8 @@
   }
   &:global(.ant-tabs-card > .ant-tabs-nav > .ant-tabs-nav-wrap .ant-tabs-tab.ant-tabs-tab-active) {
     border-bottom-color: transparent !important;
+
+    @include e.elevation;
   }
   &:global(.ant-tabs-card > .ant-tabs-nav) {
     margin: 0;
@@ -94,6 +46,8 @@
     border-radius: 0 0 var(--theme-border-radius-weak) var(--theme-border-radius-weak);
     border-style: solid;
     border-width: 0 var(--theme-stroke-width) var(--theme-stroke-width) var(--theme-stroke-width);
+
+    @include e.elevation;
   }
   &:global(.ant-tabs-card > .ant-tabs-content-holder > .ant-tabs-content) {
     padding: 16px;

--- a/src/kit/Pivot.module.scss
+++ b/src/kit/Pivot.module.scss
@@ -78,7 +78,7 @@
   &:global(.ant-tabs-card > .ant-tabs-nav > .ant-tabs-nav-wrap .ant-tabs-tab) {
     background-color: var(--theme-surface-strong);
     border-color: var(--theme-surface-border);
-    border-radius: var(--theme-border-radius) var(--theme-border-radius) 0 0;
+    border-radius: var(--theme-border-radius-weak) var(--theme-border-radius-weak) 0 0;
   }
   &:global(.ant-tabs-card > .ant-tabs-nav > .ant-tabs-nav-wrap .ant-tabs-tab:hover) {
     background-color: var(--theme-surface);
@@ -91,7 +91,7 @@
     margin: 0;
   }
   &:global(.ant-tabs-card > .ant-tabs-content-holder) {
-    border-radius: 0 0 var(--theme-border-radius) var(--theme-border-radius);
+    border-radius: 0 0 var(--theme-border-radius-weak) var(--theme-border-radius-weak);
     border-style: solid;
     border-width: 0 var(--theme-stroke-width) var(--theme-stroke-width) var(--theme-stroke-width);
   }

--- a/src/kit/Pivot.tsx
+++ b/src/kit/Pivot.tsx
@@ -42,7 +42,7 @@ const Pivot: React.FC<PivotProps> = ({ type = 'primary', items, ...props }) => {
     themeSettings: { className: themeClass },
   } = useTheme();
   const currentElevation = useContext(ElevationContext);
-  const elevationClasses = [css.e0, css.e1, css.e2, css.e3, css.e4];
+  const elevationClasses = [css.zero, css.one, css.two, css.three, css.four];
   const tabType = convertTabType(type);
   const classes = [themeClass, css.base, elevationClasses[currentElevation]];
 

--- a/src/kit/Pivot.tsx
+++ b/src/kit/Pivot.tsx
@@ -1,8 +1,8 @@
 import { Tabs, TabsProps } from 'antd';
-import React, { KeyboardEvent, MouseEvent, ReactNode, useContext, useMemo } from 'react';
+import React, { KeyboardEvent, MouseEvent, ReactNode, useMemo } from 'react';
 
-import { ElevationContext } from 'kit/internal/Elevation';
-import { ElevationLevels, useTheme } from 'kit/Theme';
+import { ElevationContext, useElevation } from 'kit/internal/Elevation';
+import { useTheme } from 'kit/Theme';
 
 import css from './Pivot.module.scss';
 
@@ -41,22 +41,21 @@ const Pivot: React.FC<PivotProps> = ({ type = 'primary', items, ...props }) => {
   const {
     themeSettings: { className: themeClass },
   } = useTheme();
-  const currentElevation = useContext(ElevationContext);
-  const elevationClasses = [css.zero, css.one, css.two, css.three, css.four];
   const tabType = convertTabType(type);
-  const classes = [themeClass, css.base, elevationClasses[currentElevation]];
+  const { elevationClass, nextElevation } = useElevation();
+  const classes = [themeClass, css.base, elevationClass];
 
   const elevatedItems = useMemo(
     () =>
       items?.map((item) => ({
         ...item,
         children: (
-          <ElevationContext.Provider value={Math.min(currentElevation + 1, 4) as ElevationLevels}>
+          <ElevationContext.Provider value={nextElevation}>
             {item.children}
           </ElevationContext.Provider>
         ),
       })),
-    [currentElevation, items],
+    [items, nextElevation],
   );
   return <Tabs className={classes.join(' ')} items={elevatedItems} type={tabType} {...props} />;
 };

--- a/src/kit/Pivot.tsx
+++ b/src/kit/Pivot.tsx
@@ -1,7 +1,8 @@
 import { Tabs, TabsProps } from 'antd';
-import React, { KeyboardEvent, MouseEvent, ReactNode } from 'react';
+import React, { KeyboardEvent, MouseEvent, ReactNode, useContext, useMemo } from 'react';
 
-import { useTheme } from 'kit/Theme';
+import { ElevationContext } from 'kit/internal/Elevation';
+import { ElevationLevels, useTheme } from 'kit/Theme';
 
 import css from './Pivot.module.scss';
 
@@ -36,13 +37,28 @@ const convertTabType = (type: PivotTabType): TabsProps['type'] => {
   }
 };
 
-const Pivot: React.FC<PivotProps> = ({ type = 'primary', ...props }) => {
+const Pivot: React.FC<PivotProps> = ({ type = 'primary', items, ...props }) => {
   const {
     themeSettings: { className: themeClass },
   } = useTheme();
+  const currentElevation = useContext(ElevationContext);
+  const elevationClasses = [css.e0, css.e1, css.e2, css.e3, css.e4];
   const tabType = convertTabType(type);
-  const classes = [themeClass, css.base];
-  return <Tabs className={classes.join(' ')} type={tabType} {...props} />;
+  const classes = [themeClass, css.base, elevationClasses[currentElevation]];
+
+  const elevatedItems = useMemo(
+    () =>
+      items?.map((item) => ({
+        ...item,
+        children: (
+          <ElevationContext.Provider value={Math.min(currentElevation + 1, 4) as ElevationLevels}>
+            {item.children}
+          </ElevationContext.Provider>
+        ),
+      })),
+    [currentElevation, items],
+  );
+  return <Tabs className={classes.join(' ')} items={elevatedItems} type={tabType} {...props} />;
 };
 
 export default Pivot;

--- a/src/kit/Surface.module.scss
+++ b/src/kit/Surface.module.scss
@@ -1,5 +1,5 @@
 .base {
-  border-radius: var(--theme-border-radius);
+  border-radius: var(--theme-border-radius-weak);
   flex-grow: 1;
   height: 100%;
   padding: 8px;

--- a/src/kit/Surface.module.scss
+++ b/src/kit/Surface.module.scss
@@ -1,11 +1,7 @@
-/* stylelint-disable no-descending-specificity */
-@use 'sass:map';
-@use 'internal/Elevation.module.scss';
-
 .base {
   border-radius: var(--theme-border-radius);
   flex-grow: 1;
+  height: 100%;
   padding: 8px;
-
-  @extend %base, .border;
+  width: 100%;
 }

--- a/src/kit/Surface.module.scss
+++ b/src/kit/Surface.module.scss
@@ -1,114 +1,11 @@
 /* stylelint-disable no-descending-specificity */
 @use 'sass:map';
-
-$levels: (
-  0: var(--theme-elevation-0-bg),
-  1: var(--theme-elevation-1-bg),
-  2: var(--theme-elevation-2-bg),
-  3: var(--theme-elevation-3-bg),
-  4: var(--theme-elevation-4-bg),
-);
-$level-highlights: (
-  0: var(--theme-elevation-0-hover),
-  1: var(--theme-elevation-1-hover),
-  2: var(--theme-elevation-2-hover),
-  3: var(--theme-elevation-3-hover),
-  4: var(--theme-elevation-4-hover),
-);
-$border-colors: (
-  0: var(--theme-elevation-0-border),
-  1: var(--theme-elevation-1-border),
-  2: var(--theme-elevation-2-border),
-  3: var(--theme-elevation-3-border),
-  4: var(--theme-elevation-4-border),
-);
-
-@mixin surface($level: 1) {
-  background-color: map.get($levels, $level);
-  border: var(--theme-stroke-width) solid map.get($border-colors, $level);
-
-  &.hover:hover {
-    background-color: map.get($level-highlights, $level);
-  }
-}
+@use 'internal/Elevation.module.scss';
 
 .base {
   border-radius: var(--theme-border-radius);
   flex-grow: 1;
-  height: 100%;
   padding: 8px;
-  width: 100%;
 
-  .base {
-    .base {
-      .base {
-        @include surface(4);
-      }
-
-      @include surface(3);
-    }
-
-    @include surface(2);
-  }
-  &.zero {
-    .base {
-      .base {
-        .base {
-          .base {
-            @include surface(4);
-          }
-
-          @include surface(3);
-        }
-
-        @include surface(2);
-      }
-
-      @include surface(1);
-    }
-
-    @include surface(0);
-  }
-  &.one {
-    .base {
-      .base {
-        .base {
-          @include surface(4);
-        }
-
-        @include surface(3);
-      }
-
-      @include surface(2);
-    }
-
-    @include surface(1);
-  }
-  &.two {
-    .base {
-      .base {
-        @include surface(4);
-      }
-
-      @include surface(3);
-    }
-
-    @include surface(2);
-  }
-  &.three {
-    .base {
-      @include surface(4);
-    }
-
-    @include surface(3);
-  }
-  &.four {
-    .base {
-      @include surface(4);
-    }
-
-    @include surface(4);
-  }
-
-  @include surface(1);
+  @extend %base, .border;
 }

--- a/src/kit/Surface.tsx
+++ b/src/kit/Surface.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { ElevationWrapper } from 'kit/internal/useElevation';
+import { ElevationWrapper } from 'kit/internal/Elevation';
 import { ElevationLevels, useTheme } from 'kit/Theme';
 
 import css from './Surface.module.scss';

--- a/src/kit/Surface.tsx
+++ b/src/kit/Surface.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
-import { useTheme } from 'kit/Theme';
+import { ElevationWrapper } from 'kit/internal/useElevation';
+import { ElevationLevels, useTheme } from 'kit/Theme';
 
 import css from './Surface.module.scss';
-import { Elevation } from './Theme';
 interface Props {
   children?: React.ReactNode;
-  elevationOverride?: Elevation;
+  elevationOverride?: ElevationLevels;
   hover?: boolean;
 }
 
@@ -16,11 +16,15 @@ const Surface: React.FC<Props> = ({ children, elevationOverride, hover }: Props)
   } = useTheme();
   const classes = [css.base, themeClass];
 
-  if (hover) classes.push(css.hover);
-  const overrideClasses = [css.zero, css.one, css.two, css.three, css.four];
-  if (elevationOverride !== undefined) classes.push(overrideClasses[elevationOverride]);
-
-  return <div className={classes.join(' ')}>{children}</div>;
+  return (
+    <ElevationWrapper
+      border={true}
+      className={classes.join(' ')}
+      elevationOverride={elevationOverride}
+      hover={hover}>
+      {children}
+    </ElevationWrapper>
+  );
 };
 
 export default Surface;

--- a/src/kit/Surface.tsx
+++ b/src/kit/Surface.tsx
@@ -18,7 +18,7 @@ const Surface: React.FC<Props> = ({ children, elevationOverride, hover }: Props)
 
   return (
     <ElevationWrapper
-      border={true}
+      border
       className={classes.join(' ')}
       elevationOverride={elevationOverride}
       hover={hover}>

--- a/src/kit/Theme/themes.ts
+++ b/src/kit/Theme/themes.ts
@@ -125,4 +125,4 @@ export const getStateColorCssVar = (
   return `var(--theme-status-${name}${on}${strongWeak})`;
 };
 
-export type Elevation = 0 | 1 | 2 | 3 | 4;
+export type ElevationLevels = 0 | 1 | 2 | 3 | 4;

--- a/src/kit/internal/Elevation.module.scss
+++ b/src/kit/internal/Elevation.module.scss
@@ -1,0 +1,113 @@
+/* stylelint-disable no-descending-specificity */
+@use 'sass:map';
+
+$levels: (
+  0: var(--theme-elevation-0-bg),
+  1: var(--theme-elevation-1-bg),
+  2: var(--theme-elevation-2-bg),
+  3: var(--theme-elevation-3-bg),
+  4: var(--theme-elevation-4-bg),
+);
+$level-highlights: (
+  0: var(--theme-elevation-0-hover),
+  1: var(--theme-elevation-1-hover),
+  2: var(--theme-elevation-2-hover),
+  3: var(--theme-elevation-3-hover),
+  4: var(--theme-elevation-4-hover),
+);
+$border-colors: (
+  0: var(--theme-elevation-0-border),
+  1: var(--theme-elevation-1-border),
+  2: var(--theme-elevation-2-border),
+  3: var(--theme-elevation-3-border),
+  4: var(--theme-elevation-4-border),
+);
+
+@mixin elevation($level: 1) {
+  background-color: map.get($levels, $level);
+
+  &.hover:hover {
+    background-color: map.get($level-highlights, $level);
+  }
+  &.border {
+    border: var(--theme-stroke-width) solid map.get($border-colors, $level);
+  }
+}
+
+%base {
+  height: 100%;
+  width: 100%;
+
+  %base {
+    %base {
+      %base {
+        @include elevation(4);
+      }
+
+      @include elevation(3);
+    }
+
+    @include elevation(2);
+  }
+  &.zero {
+    %base {
+      %base {
+        %base {
+          %base {
+            @include elevation(4);
+          }
+
+          @include elevation(3);
+        }
+
+        @include elevation(2);
+      }
+
+      @include elevation(1);
+    }
+
+    @include elevation(0);
+  }
+  &.one {
+    %base {
+      %base {
+        %base {
+          @include elevation(4);
+        }
+
+        @include elevation(3);
+      }
+
+      @include elevation(2);
+    }
+
+    @include elevation(1);
+  }
+  &.two {
+    %base {
+      %base {
+        @include elevation(4);
+      }
+
+      @include elevation(3);
+    }
+
+    @include elevation(2);
+  }
+  &.three {
+    %base {
+      @include elevation(4);
+    }
+
+    @include elevation(3);
+  }
+  &.four {
+    %base {
+      @include elevation(4);
+    }
+
+    @include elevation(4);
+  }
+
+  @include elevation(1);
+}

--- a/src/kit/internal/Elevation.module.scss
+++ b/src/kit/internal/Elevation.module.scss
@@ -1,5 +1,8 @@
+/* stylelint-disable order/order */
 /* stylelint-disable no-descending-specificity */
 @use 'sass:map';
+@use 'sass:meta';
+@use 'sass:math';
 
 $levels: (
   0: var(--theme-elevation-0-bg),
@@ -23,8 +26,9 @@ $border-colors: (
   4: var(--theme-elevation-4-border),
 );
 
-@mixin elevation($level: 1) {
+@mixin elevation-layer($level: 1) {
   background-color: map.get($levels, $level);
+  border-color: map.get($border-colors, $level);
 
   &.hover:hover {
     background-color: map.get($level-highlights, $level);
@@ -34,80 +38,45 @@ $border-colors: (
   }
 }
 
-%base {
-  height: 100%;
-  width: 100%;
+// taken from https://stackoverflow.com/a/63250918
+@mixin nested($depth: 1) {
+  $self: &;
 
-  %base {
-    %base {
-      %base {
-        @include elevation(4);
-      }
-
-      @include elevation(3);
+  @for $i from 1 through $depth {
+    #{$self} {
+      @content;
     }
 
-    @include elevation(2);
+    $self: #{$self + ' ' + &};
   }
+}
+
+@mixin elevation($base-elevation: 1) {
+  $max-elevation: 4;
+
+  @include elevation-layer($base-elevation);
+
+  @include nested($max-elevation + 1 - $base-elevation) {
+    $base-elevation: math.clamp(0, $base-elevation + 1, $max-elevation);
+
+    @include elevation-layer($base-elevation);
+  }
+}
+
+.base {
   &.zero {
-    %base {
-      %base {
-        %base {
-          %base {
-            @include elevation(4);
-          }
-
-          @include elevation(3);
-        }
-
-        @include elevation(2);
-      }
-
-      @include elevation(1);
-    }
-
-    @include elevation(0);
+    @include elevation-layer(0);
   }
   &.one {
-    %base {
-      %base {
-        %base {
-          @include elevation(4);
-        }
-
-        @include elevation(3);
-      }
-
-      @include elevation(2);
-    }
-
-    @include elevation(1);
+    @include elevation-layer(1);
   }
   &.two {
-    %base {
-      %base {
-        @include elevation(4);
-      }
-
-      @include elevation(3);
-    }
-
-    @include elevation(2);
+    @include elevation-layer(2);
   }
   &.three {
-    %base {
-      @include elevation(4);
-    }
-
-    @include elevation(3);
+    @include elevation-layer(3);
   }
   &.four {
-    %base {
-      @include elevation(4);
-    }
-
-    @include elevation(4);
+    @include elevation-layer(4);
   }
-
-  @include elevation(1);
 }

--- a/src/kit/internal/Elevation.module.scss
+++ b/src/kit/internal/Elevation.module.scss
@@ -4,6 +4,8 @@
 @use 'sass:meta';
 @use 'sass:math';
 
+$min-elevation: 0;
+$max-elevation: 4;
 $levels: (
   0: var(--theme-elevation-0-bg),
   1: var(--theme-elevation-1-bg),
@@ -26,32 +28,30 @@ $border-colors: (
   4: var(--theme-elevation-4-border),
 );
 
-@mixin elevation($level: 1) {
-  background-color: map.get($levels, $level);
-  border-color: map.get($border-colors, $level);
-
-  &.hover:hover {
-    background-color: map.get($level-highlights, $level);
-  }
-  &.border {
-    border: var(--theme-stroke-width) solid map.get($border-colors, $level);
+@mixin generate-variables {
+  @for $level from $min-elevation through $max-elevation {
+    .elevation-#{$level} {
+      --theme-elevation-current-bg: #{map.get($levels, $level)};
+      --theme-elevation-current-border: #{map.get($border-colors, $level)};
+      --theme-elevation-current-bg-highlight: #{map.get($level-highlights, $level)};
+    }
   }
 }
 
-.base {
-  &.ezero {
-    @include elevation(0);
+@mixin elevation {
+  background-color: var(--theme-elevation-current-bg);
+  border-color: var(--theme-elevation-current-border);
+
+  &.hover:hover {
+    background-color: var(--theme-elevation-current-bg-highlight);
   }
-  &.eone {
-    @include elevation(1);
+  &.border {
+    border: var(--theme-stroke-width) solid var(--theme-elevation-current-border);
   }
-  &.etwo {
-    @include elevation(2);
-  }
-  &.ethree {
-    @include elevation(3);
-  }
-  &.efour {
-    @include elevation(4);
-  }
+}
+
+@include generate-variables;
+
+.elevationBase {
+  @include elevation;
 }

--- a/src/kit/internal/Elevation.module.scss
+++ b/src/kit/internal/Elevation.module.scss
@@ -38,45 +38,20 @@ $border-colors: (
   }
 }
 
-// taken from https://stackoverflow.com/a/63250918
-@mixin nested($depth: 1) {
-  $self: &;
-
-  @for $i from 1 through $depth {
-    #{$self} {
-      @content;
-    }
-
-    $self: #{$self + ' ' + &};
-  }
-}
-
-// @mixin elevation($base-elevation: 1) {
-//   $max-elevation: 4;
-
-//   @include elevation-layer($base-elevation);
-
-//   @include nested($max-elevation + 1 - $base-elevation) {
-//     $base-elevation: math.clamp(0, $base-elevation + 1, $max-elevation);
-
-//     @include elevation-layer($base-elevation);
-//   }
-// }
-
 .base {
-  &.zero {
+  &.ezero {
     @include elevation(0);
   }
-  &.one {
+  &.eone {
     @include elevation(1);
   }
-  &.two {
+  &.etwo {
     @include elevation(2);
   }
-  &.three {
+  &.ethree {
     @include elevation(3);
   }
-  &.four {
+  &.efour {
     @include elevation(4);
   }
 }

--- a/src/kit/internal/Elevation.module.scss
+++ b/src/kit/internal/Elevation.module.scss
@@ -26,7 +26,7 @@ $border-colors: (
   4: var(--theme-elevation-4-border),
 );
 
-@mixin elevation-layer($level: 1) {
+@mixin elevation($level: 1) {
   background-color: map.get($levels, $level);
   border-color: map.get($border-colors, $level);
 
@@ -51,32 +51,32 @@ $border-colors: (
   }
 }
 
-@mixin elevation($base-elevation: 1) {
-  $max-elevation: 4;
+// @mixin elevation($base-elevation: 1) {
+//   $max-elevation: 4;
 
-  @include elevation-layer($base-elevation);
+//   @include elevation-layer($base-elevation);
 
-  @include nested($max-elevation + 1 - $base-elevation) {
-    $base-elevation: math.clamp(0, $base-elevation + 1, $max-elevation);
+//   @include nested($max-elevation + 1 - $base-elevation) {
+//     $base-elevation: math.clamp(0, $base-elevation + 1, $max-elevation);
 
-    @include elevation-layer($base-elevation);
-  }
-}
+//     @include elevation-layer($base-elevation);
+//   }
+// }
 
 .base {
   &.zero {
-    @include elevation-layer(0);
+    @include elevation(0);
   }
   &.one {
-    @include elevation-layer(1);
+    @include elevation(1);
   }
   &.two {
-    @include elevation-layer(2);
+    @include elevation(2);
   }
   &.three {
-    @include elevation-layer(3);
+    @include elevation(3);
   }
   &.four {
-    @include elevation-layer(4);
+    @include elevation(4);
   }
 }

--- a/src/kit/internal/Elevation.module.scss
+++ b/src/kit/internal/Elevation.module.scss
@@ -41,6 +41,12 @@ $border-colors: (
 @mixin elevation {
   background-color: var(--theme-elevation-current-bg);
   border-color: var(--theme-elevation-current-border);
+}
+
+@include generate-variables;
+
+.elevationBase {
+  @include elevation;
 
   &.hover:hover {
     background-color: var(--theme-elevation-current-bg-highlight);
@@ -48,10 +54,4 @@ $border-colors: (
   &.border {
     border: var(--theme-stroke-width) solid var(--theme-elevation-current-border);
   }
-}
-
-@include generate-variables;
-
-.elevationBase {
-  @include elevation;
 }

--- a/src/kit/internal/Elevation.tsx
+++ b/src/kit/internal/Elevation.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, CSSProperties, useContext } from 'react';
+import React, { createContext, useContext } from 'react';
 
 import { ElevationLevels, useTheme } from 'kit/Theme';
 
@@ -22,7 +22,6 @@ export const ElevationWrapper: React.FC<Props> = ({
   const {
     themeSettings: { className: themeClass },
   } = useTheme();
-  const ElevationContext = useElevation();
   let currentElevation = useContext(ElevationContext);
   if (elevationOverride !== undefined) currentElevation = elevationOverride;
   const elevationClasses = [css.zero, css.one, css.two, css.three, css.four];
@@ -31,10 +30,7 @@ export const ElevationWrapper: React.FC<Props> = ({
   if (hover) classes.push(css.hover);
   if (border) classes.push(css.border);
   return (
-    <div
-      className={classes.join(' ')}
-      style={{ '--current-elevation': currentElevation } as CSSProperties}
-      {...props}>
+    <div className={classes.join(' ')} {...props}>
       <ElevationContext.Provider value={Math.min(currentElevation + 1, 4) as ElevationLevels}>
         {children}
       </ElevationContext.Provider>
@@ -42,15 +38,4 @@ export const ElevationWrapper: React.FC<Props> = ({
   );
 };
 
-const useElevation = (): React.Context<ElevationLevels> => {
-  const ElevationContext = createContext<ElevationLevels>(0);
-
-  // const currentElevation = useContext(ElevationContext);
-  // <div className={someCssStuff(currentElevation)}>
-  //   <ElevationContext.Provider value={currentElevation + 1}>{children}</ElevationContext.Provider>
-  // </div>;
-
-  return ElevationContext;
-};
-
-export default useElevation;
+export const ElevationContext = createContext<ElevationLevels>(1);

--- a/src/kit/internal/Elevation.tsx
+++ b/src/kit/internal/Elevation.tsx
@@ -23,12 +23,12 @@ export const ElevationWrapper: React.FC<Props> = ({
     themeSettings: { className: themeClass },
   } = useTheme();
   const { elevationClass, nextElevation } = useElevation({
-    border,
     elevationOverride,
-    hover,
   });
 
   const classes = [themeClass, className, css.elevationBase, elevationClass];
+  if (hover) classes.push(css.hover);
+  if (border) classes.push(css.border);
   return (
     <div className={classes.join(' ')} {...props}>
       <ElevationContext.Provider value={nextElevation}>{children}</ElevationContext.Provider>
@@ -40,8 +40,6 @@ export const ElevationContext = createContext<ElevationLevels>(1);
 
 interface ElevationProps {
   elevationOverride?: ElevationLevels;
-  border?: boolean;
-  hover?: boolean;
 }
 interface ElevationHook {
   currentElevation: ElevationLevels;
@@ -49,17 +47,11 @@ interface ElevationHook {
   nextElevation: ElevationLevels;
 }
 
-export const useElevation = ({
-  elevationOverride,
-  border,
-  hover,
-}: ElevationProps = {}): ElevationHook => {
+export const useElevation = ({ elevationOverride }: ElevationProps = {}): ElevationHook => {
   let currentElevation = useContext(ElevationContext);
   if (elevationOverride !== undefined) currentElevation = elevationOverride;
 
   const classes = [css[`elevation-${currentElevation}`]];
-  if (hover) classes.push(css.hover);
-  if (border) classes.push(css.border);
 
   return {
     currentElevation,

--- a/src/kit/internal/Elevation.tsx
+++ b/src/kit/internal/Elevation.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext } from 'react';
+import React, { createContext, useContext, useMemo } from 'react';
 
 import { ElevationLevels, useTheme } from 'kit/Theme';
 
@@ -51,11 +51,14 @@ export const useElevation = ({ elevationOverride }: ElevationProps = {}): Elevat
   let currentElevation = useContext(ElevationContext);
   if (elevationOverride !== undefined) currentElevation = elevationOverride;
 
-  return React.useMemo(()=> {
-    currentElevation,
-    elevationClass: css[`elevation-${currentElevation}`],
-    nextElevation: Math.min(currentElevation + 1, 4) as ElevationLevels,
-  }, [currentElevation]);
+  return useMemo(
+    () => ({
+      currentElevation,
+      elevationClass: css[`elevation-${currentElevation}`],
+      nextElevation: Math.min(currentElevation + 1, 4) as ElevationLevels,
+    }),
+    [currentElevation],
+  );
 };
 
 /* For basic implementation wrap your component in ElevationWrapper. Surface is the simplest example.

--- a/src/kit/internal/Elevation.tsx
+++ b/src/kit/internal/Elevation.tsx
@@ -24,7 +24,7 @@ export const ElevationWrapper: React.FC<Props> = ({
   } = useTheme();
   let currentElevation = useContext(ElevationContext);
   if (elevationOverride !== undefined) currentElevation = elevationOverride;
-  const elevationClasses = [css.zero, css.one, css.two, css.three, css.four];
+  const elevationClasses = [css.ezero, css.eone, css.etwo, css.ethree, css.efour];
 
   const classes = [themeClass, className, css.base, elevationClasses[currentElevation]];
   if (hover) classes.push(css.hover);
@@ -37,5 +37,28 @@ export const ElevationWrapper: React.FC<Props> = ({
     </div>
   );
 };
+
+/* For basic implementation wrap your component in ElevationWrapper. Surface is the simplest example.
+ * If you need to do something more complicated it will require some SCSS work.
+ * In your component enter the following:
+ *
+ * const currentElevation = useContext(ElevationContext);
+ * const elevationClasses = [css.zero, css.one, css.two, css.three, css.four];
+ *
+ * and then add `elevationClasses[currentElevation]` to your list of classes.
+ * At the top of your <component>.module.scss file put the line:
+ *
+ * @use 'internal/Elevation.module.scss' as e;
+ *
+ * Then create the classes mentioned above like so:
+ *
+ * &.zero {
+ *   <selector that needs elevation> {
+ *     @include e.elevation(0);
+ *   }
+ * }
+ *
+ * And so on. For an example, look at the Pivot component.
+ */
 
 export const ElevationContext = createContext<ElevationLevels>(1);

--- a/src/kit/internal/Elevation.tsx
+++ b/src/kit/internal/Elevation.tsx
@@ -51,13 +51,11 @@ export const useElevation = ({ elevationOverride }: ElevationProps = {}): Elevat
   let currentElevation = useContext(ElevationContext);
   if (elevationOverride !== undefined) currentElevation = elevationOverride;
 
-  const classes = [css[`elevation-${currentElevation}`]];
-
-  return {
+  return React.useMemo(()=> {
     currentElevation,
-    elevationClass: classes.join(' '),
+    elevationClass: css[`elevation-${currentElevation}`],
     nextElevation: Math.min(currentElevation + 1, 4) as ElevationLevels,
-  };
+  }, [currentElevation]);
 };
 
 /* For basic implementation wrap your component in ElevationWrapper. Surface is the simplest example.

--- a/src/kit/internal/useElevation.tsx
+++ b/src/kit/internal/useElevation.tsx
@@ -1,0 +1,56 @@
+import React, { createContext, CSSProperties, useContext } from 'react';
+
+import { ElevationLevels, useTheme } from 'kit/Theme';
+
+import css from './Elevation.module.scss';
+
+interface Props
+  extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
+  border?: boolean;
+  hover?: boolean;
+  elevationOverride?: ElevationLevels;
+}
+
+export const ElevationWrapper: React.FC<Props> = ({
+  border = false,
+  children,
+  className,
+  elevationOverride,
+  hover = false,
+  ...props
+}: Props) => {
+  const {
+    themeSettings: { className: themeClass },
+  } = useTheme();
+  const ElevationContext = useElevation();
+  let currentElevation = useContext(ElevationContext);
+  if (elevationOverride !== undefined) currentElevation = elevationOverride;
+  const elevationClasses = [css.zero, css.one, css.two, css.three, css.four];
+
+  const classes = [themeClass, className, css.base, elevationClasses[currentElevation]];
+  if (hover) classes.push(css.hover);
+  if (border) classes.push(css.border);
+  return (
+    <div
+      className={classes.join(' ')}
+      style={{ '--current-elevation': currentElevation } as CSSProperties}
+      {...props}>
+      <ElevationContext.Provider value={Math.min(currentElevation + 1, 4) as ElevationLevels}>
+        {children}
+      </ElevationContext.Provider>
+    </div>
+  );
+};
+
+const useElevation = (): React.Context<ElevationLevels> => {
+  const ElevationContext = createContext<ElevationLevels>(0);
+
+  // const currentElevation = useContext(ElevationContext);
+  // <div className={someCssStuff(currentElevation)}>
+  //   <ElevationContext.Provider value={currentElevation + 1}>{children}</ElevationContext.Provider>
+  // </div>;
+
+  return ElevationContext;
+};
+
+export default useElevation;


### PR DESCRIPTION
Extracting Elevation from the Surface component was the bulk of the work here. I went pretty far down the CSS rabbit-hole before concluding that it wasn't feasible and moved to React Context.

I created two methods for applying elevation to a component. The simple one is wrapping it in and `<ElevationWrapper>`, which is just a `div` with some extra logic for handling the context. For more complicated applications like Pivot, where we only want certain sections to have elevation applied it gets trickier, but I wrote out a comment in the Elevation.tsx file explaining the process. I'll duplicate it here:

```
For basic implementation wrap your component in ElevationWrapper. Surface is the simplest example.
If you need to do something more complicated it will require a little more work.
In your component enter the following:

const { elevationClass, nextElevation } = useElevation();

and then add elevationClass to your list of classes. Next, surround the section of
your component using elevation with the following:

<ElevationContext.Provider value={nextElevation}>
   <component>
</ElevationContext.Provider>

At the top of your <component>.module.scss file put the line:

@use 'internal/Elevation.module.scss' as e;

Finally, at the selectors that need elevation applied add `@include e.elevation`.
For an example, look at the Pivot component.
```