### PR TITLE
fix: `DocumentCards` width

### DIFF
--- a/src/kit/DocumentCards.module.scss
+++ b/src/kit/DocumentCards.module.scss
@@ -58,6 +58,9 @@
   display: flex;
   justify-content: flex-end;
 }
+.docsContainer {
+  width: 100%;
+}
 
 @media only screen and (max-width: $breakpoint-tablet) {
   .base {


### PR DESCRIPTION
[WEB-1834]

`DocumentCards` is only used in `RichTextEditor` so far, so check if `RichTextEditor` view width is full in preview

[WEB-1834]: https://hpe-aiatscale.atlassian.net/browse/WEB-1834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ