### PR TITLE
fix: Adjust for updates to checkpoints, simulate in streaming data [WEB-1823]

### DIFF
--- a/src/DesignKit.tsx
+++ b/src/DesignKit.tsx
@@ -28,6 +28,7 @@ import InputShortcut, { KeyboardShortcut } from 'kit/InputShortcut';
 import { hex2hsl } from 'kit/internal/functions';
 import { getSystemMode, Mode } from 'kit/internal/Theme/theme';
 import { Document, Log, LogLevel, Serie, XAxisDomain } from 'kit/internal/types';
+import { drawPointsPlugin } from 'kit/internal/UPlot/UPlotChart/drawPointsPlugin';
 import { LineChart } from 'kit/LineChart';
 import { SyncProvider } from 'kit/LineChart/SyncProvider';
 import { useChartGrid } from 'kit/LineChart/useChartGrid';
@@ -909,6 +910,20 @@ const ChartsSection: React.FC = () => {
 
   const line1BatchesDataStreamed = useMemo(() => line1Data.slice(0, timer), [timer, line1Data]);
   const line2BatchesDataStreamed = useMemo(() => line2Data.slice(0, timer), [timer, line2Data]);
+  const drawCheckpointsStreamed = useMemo(() => {
+    if (!timer || !line1Data.length) return [];
+    const pt = line1Data[Math.min(timer, line1Data.length) - 1];
+    return [
+      drawPointsPlugin({
+        [pt[0]]: {
+          experimentId: 0,
+          state: 'COMPLETED',
+          totalBatches: pt[0],
+          trialId: 0,
+        },
+      }),
+    ];
+  }, [timer, line1Data]);
 
   const line1: Serie = {
     color: '#009BDE',
@@ -1002,6 +1017,7 @@ const ChartsSection: React.FC = () => {
         <LineChart
           handleError={handleError}
           height={250}
+          plugins={drawCheckpointsStreamed}
           series={[line1, line2]}
           showLegend={true}
           title="Sample"
@@ -1017,6 +1033,7 @@ const ChartsSection: React.FC = () => {
           focusedSeries={1}
           handleError={handleError}
           height={250}
+          plugins={drawCheckpointsStreamed}
           series={[line1, line2]}
           title="Sample"
         />

--- a/src/kit/internal/UPlot/UPlotChart.tsx
+++ b/src/kit/internal/UPlot/UPlotChart.tsx
@@ -1,3 +1,4 @@
+import { isEqual } from 'lodash';
 import React, { RefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { throttle } from 'throttle-debounce';
 import uPlot, { AlignedData } from 'uplot';
@@ -43,7 +44,7 @@ const shouldRecreate = (
   if (Object.keys(prev).length !== Object.keys(next).length) return true;
 
   if (prev.axes?.length !== next.axes?.length) return true;
-
+  if (!isEqual(prev.plugins, next.plugins)) return true;
   if (prev?.series?.length !== next.series?.length) return true;
 
   const someScaleHasChanged = Object.entries(next.scales ?? {}).some(([scaleKey, nextScale]) => {


### PR DESCRIPTION
While running longer-running experiments, we might update the best checkpoint. The bug report is that we don't update the chart (I assume until reloading the chart/page)

Checkpoints are rendered by passing a dictionary to `drawPointsPlugin`, then sending that plugin to the chart component via `<LineChart plugins={plugins}/>}`

My theory is that the checkpoints were not redrawn because changing the plugins param alone does not update the chart drawing. To simulate updates to plugins, the "Stream line data" button includes a checkpoint updated to be the last point of the line.