### PR TITLE
chore: UI page toggle is interactive [WEB-1831]

### DIFF
--- a/src/DesignKit.tsx
+++ b/src/DesignKit.tsx
@@ -3401,6 +3401,8 @@ const ToastSection: React.FC = () => {
 };
 
 const ToggleSection: React.FC = () => {
+  const [toggleA, setToggleA] = useState(true);
+
   return (
     <ComponentSection id="Toggle">
       <AntDCard>
@@ -3413,7 +3415,7 @@ const ToggleSection: React.FC = () => {
         <strong>Toggle default</strong>
         <Toggle />
         <strong>Toggle variations</strong>
-        <Toggle checked={true} />
+        <Toggle checked={toggleA} onChange={setToggleA} />
         <Toggle label="Label" />
       </AntDCard>
     </ComponentSection>

--- a/src/kit/Toggle.tsx
+++ b/src/kit/Toggle.tsx
@@ -15,7 +15,7 @@ const Toggle: React.FC<Props> = ({ checked = false, label, onChange }: Props) =>
   const [toggled, setToggled] = useState(checked);
   useEffect(() => {
     setToggled(checked);
-  }, [checked, setToggled]);
+  }, [checked]);
 
   const handleClick = useCallback(() => {
     if (onChange) {

--- a/src/kit/Toggle.tsx
+++ b/src/kit/Toggle.tsx
@@ -1,5 +1,5 @@
 import { Switch } from 'antd';
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import Label from 'kit/internal/Label';
 
@@ -12,15 +12,24 @@ interface Props {
 }
 
 const Toggle: React.FC<Props> = ({ checked = false, label, onChange }: Props) => {
+  const [toggled, setToggled] = useState(checked);
+  useEffect(() => {
+    setToggled(checked);
+  }, [checked, setToggled]);
+
   const handleClick = useCallback(() => {
-    if (onChange) onChange(!checked);
-  }, [checked, onChange]);
+    if (onChange) {
+      onChange(!toggled);
+    } else {
+      setToggled(!toggled);
+    }
+  }, [toggled, onChange, setToggled]);
 
   return (
     <Row>
       <Column width="hug">{label && <Label type="textOnly">{label}</Label>}</Column>
       <Column width="hug">
-        <Switch checked={checked} size="small" onClick={handleClick} />
+        <Switch checked={toggled} size="small" onClick={handleClick} />
       </Column>
     </Row>
   );


### PR DESCRIPTION
Initial ticket: the example`Toggle`s on the DesignKit page were fixed at true or false, and should be switchable. Currently if no `checked` state is sent, it is permanently set to false.

This PR: adds a `toggled` state to the component. When it is placed without the `checked` and `onChange` props, it can handle checking and unchecking itself.

Alternatives:
- instead of useState/useEffect we could require the `checked` prop, making the user and DesignKit provide a static or toggle-able `Toggle`
- we could limit changes to the DesignKit page to add a state for each `Toggle`