### PR TITLE
fix: default designkit theme to system theme

### DIFF
--- a/src/DesignKit.tsx
+++ b/src/DesignKit.tsx
@@ -4244,7 +4244,7 @@ const DesignKit: React.FC<{
 };
 
 const DesignKitContainer: React.FC = () => {
-  const [mode, setMode] = useState<Mode>(Mode.Light);
+  const [mode, setMode] = useState<Mode>(Mode.System);
   const systemMode = getSystemMode();
 
   const resolvedMode =


### PR DESCRIPTION
this fixes an issue where the design kit diff checker didn't take dark mode screenshots. when implementing the theme context, we defaulted the design kit to light mode. this broke the diff checker, because it takes dark mode screenshots by changing the colorscheme preference of the browser instead of interacting with the page. We fix this by defaulting to system mode instead.