### PR TITLE
allow for theme variables to have low specificity

### DIFF
--- a/src/DesignKit.tsx
+++ b/src/DesignKit.tsx
@@ -731,6 +731,7 @@ const UIProviderVariation: React.FC<{
   return (
     <UIProvider
       key={themeVariation.variation.name}
+      priority="low"
       theme={themeVariation.theme}
       themeIsDark={isDarkMode}>
       <UIProviderExample
@@ -4200,7 +4201,7 @@ const DesignKit: React.FC<{
 
   return (
     // wrap in an antd component so links look correct
-    <UIProvider theme={theme} themeIsDark={themeIsDark}>
+    <UIProvider priority="low" theme={theme} themeIsDark={themeIsDark}>
       <Spinner spinning={false}>
         <div className={css.base}>
           <nav className={css.default}>

--- a/src/kit/Theme/UI.tsx
+++ b/src/kit/Theme/UI.tsx
@@ -71,7 +71,7 @@ export const UIProvider: React.FC<{
 
     styles.push(`color-scheme:${themeIsDark ? 'dark' : 'light'}`);
     const style = document.createElement('style');
-    const styleString = `.${classNameRef.current}{${styles.join(';')}}`;
+    const styleString = `:where(.${classNameRef.current}){${styles.join(';')}}`;
     style.textContent = styleString;
     document.head.appendChild(style);
     /**


### PR DESCRIPTION
this adds a `priority` prop to the uiprovider which allows devs to determine the specificity of the theme being applied. By default, it's set to high, which uses a bare class selector for the theme variable css. When set to low, it wraps the class selector in the `:where()` pseudoclass, which decreases the specificity of the rules to 0. This is so the rules appear lower in the devtools panel while also allowing easy overriding of rules, even absent the react context.

Because the original high priority behavior is unchanged and still the default, this change should be non-breaking. When bumping the version in determined, we'll update any uiproviders in the app such that they use low priority, after which we should be able to safely update the library again to default to low priority across the board without disruption.

@EmilyBonar could you test drive this code and see if it causes the theme variables to appear below the other css when working in the designkit as intended?