### PR TITLE
Add extra-small size to Typography

### DIFF
--- a/src/DesignKit.tsx
+++ b/src/DesignKit.tsx
@@ -2731,6 +2731,7 @@ const TypographySection: React.FC = () => {
             <Title size={TypographySize.L}>Large Title</Title>
             <Title>Default Title</Title>
             <Title size={TypographySize.S}>Small Title</Title>
+            <Title size={TypographySize.XS}>Extra-Small Title</Title>
           </div>
           <div style={{ display: 'flex', flexDirection: 'column', marginBottom: '30px' }}>
             <strong>Body</strong>

--- a/src/kit/Typography.module.scss
+++ b/src/kit/Typography.module.scss
@@ -18,8 +18,6 @@
   --body-ln-default: 20px;
   --body-size-s: 11px;
   --body-ln-s: 16px;
-  --body-size-xs: 11px;
-  --body-ln-xs: 16px;
 
   /* Label */
   --label-size-l: 16px;
@@ -28,8 +26,6 @@
   --label-ln-default: 16px;
   --label-size-s: 11px;
   --label-ln-s: 16px;
-  --label-size-xs: 11px;
-  --label-ln-xs: 16px;
 }
 .title {
   font-family: var(--theme-font-family);
@@ -47,6 +43,10 @@
     font-size: var(--title-size-s);
     line-height: var(--title-ln-s);
   }
+  &.x-small {
+    font-size: var(--title-size-xs);
+    line-height: var(--title-ln-xs);
+  }
 }
 .body {
   font-family: var(--theme-font-family);
@@ -59,7 +59,8 @@
     font-size: var(--body-size-l);
     line-height: var(--body-ln-l);
   }
-  &.small {
+  &.small,
+  &.x-small {
     font-size: var(--body-size-s);
     line-height: var(--body-ln-s);
   }
@@ -75,7 +76,8 @@
     font-size: var(--label-size-l);
     line-height: var(--label-ln-l);
   }
-  &.small {
+  &.small,
+  &.x-small {
     font-size: var(--label-size-s);
     line-height: var(--label-ln-s);
   }

--- a/src/kit/Typography.module.scss
+++ b/src/kit/Typography.module.scss
@@ -8,6 +8,8 @@
   --title-ln-default: 28px;
   --title-size-s: 16px;
   --title-ln-s: 24px;
+  --title-size-xs: 14px;
+  --title-ln-xs: 21px;
 
   /* Body */
   --body-size-l: 16px;
@@ -16,6 +18,8 @@
   --body-ln-default: 20px;
   --body-size-s: 11px;
   --body-ln-s: 16px;
+  --body-size-xs: 11px;
+  --body-ln-xs: 16px;
 
   /* Label */
   --label-size-l: 16px;
@@ -24,6 +28,8 @@
   --label-ln-default: 16px;
   --label-size-s: 11px;
   --label-ln-s: 16px;
+  --label-size-xs: 11px;
+  --label-ln-xs: 16px;
 }
 .title {
   font-family: var(--theme-font-family);

--- a/src/kit/Typography.tsx
+++ b/src/kit/Typography.tsx
@@ -12,6 +12,7 @@ export const TypographySize = {
   Default: 'default',
   L: 'large',
   S: 'small',
+  XS: 'x-small',
 } as const;
 
 export type TypographySize = ValueOf<typeof TypographySize>;


### PR DESCRIPTION
Adds `TypographySize.XS` sizing
This is an alias for Small, except for titles where it will reduce the size to be the same used in WorkspaceCard / ProjectCard