### PR TITLE
fix: glossary width

### DIFF
--- a/src/kit/Glossary.module.scss
+++ b/src/kit/Glossary.module.scss
@@ -23,6 +23,7 @@
         max-width: 100%;
         min-width: 0;
         overflow-wrap: break-word;
+        width: 100%;
 
         .componentWrapper {
           text-align: initial;


### PR DESCRIPTION
 fix [WEB-1868]


[WEB-1868]: https://hpe-aiatscale.atlassian.net/browse/WEB-1868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

### Before

<img width="1048" alt="image" src="https://github.com/determined-ai/hew/assets/109113616/7ba109c7-6ca8-49a3-8c36-fb1bcf305145">


### After

<img width="1048" alt="image" src="https://github.com/determined-ai/hew/assets/109113616/6a4fac2d-00f1-498a-8b5c-a239ce5deac9">

