### PR TITLE
chore: add elevation to LineChart and ChartGrid

### DIFF
--- a/src/kit/LineChart.module.scss
+++ b/src/kit/LineChart.module.scss
@@ -14,11 +14,9 @@
   overflow-y: hidden;
 }
 .chartgridCell {
-  padding: 0;
   padding: var(--grid-spacing);
 }
 .chartgridCellCard {
-  border-radius: 4px;
   height: 100%;
   padding: var(--spacing-xl-3);
 }
@@ -27,9 +25,7 @@
   font-family: var(--theme-font-family);
   font-size: 14px;
   justify-content: center;
-  margin-bottom: -18px !important;
-  padding-bottom: 15px;
-  padding-top: 5px;
+  padding: 0 var(--spacing-md);
 
   @supports (font-variation-settings: normal) {
     font-family: var(--theme-font-family-var);

--- a/src/kit/LineChart.module.scss
+++ b/src/kit/LineChart.module.scss
@@ -10,24 +10,19 @@
 }
 .chartgridContainer {
   --grid-spacing: var(--spacing-sm);
-  background-color: var(--theme-background);
   min-height: 530px;
   overflow-y: hidden;
 }
 .chartgridCell {
-  background-color: var(--theme-background);
   padding: 0;
   padding: var(--grid-spacing);
 }
 .chartgridCellCard {
-  background-color: var(--theme-stage);
-  border: 1px solid var(--theme-stage-border);
   border-radius: 4px;
   height: 100%;
   padding: var(--spacing-xl-3);
 }
 .chartTitle {
-  background-color: var(--theme-stage);
   display: flex;
   font-family: var(--theme-font-family);
   font-size: 14px;

--- a/src/kit/LineChart.tsx
+++ b/src/kit/LineChart.tsx
@@ -389,10 +389,8 @@ export const ChartGrid: React.FC<GroupProps> = React.memo(
         (p) =>
           p.showLegend &&
           Loadable.ensureLoadable(p.series)
-            .map((series) =>
-              series.some((serie) => serie.data[p.xAxis ?? XAxisDomain.Batches]?.length),
-            )
-            .getOrElse(false),
+            .getOrElse([])
+            .some((serie) => serie.data[p.xAxis ?? XAxisDomain.Batches]?.length),
       );
       if (hasPopulatedSeries) {
         height += 31;

--- a/src/kit/internal/UPlot/UPlotChart.module.scss
+++ b/src/kit/internal/UPlot/UPlotChart.module.scss
@@ -1,5 +1,4 @@
 .base {
-  background-color: var(--theme-stage);
   margin-bottom: 10px;
   margin-top: 10px;
   position: relative;
@@ -33,4 +32,7 @@
 }
 .invisibleLink {
   display: none;
+}
+.base :global(.uplot) canvas {
+  background-color: transparent;
 }

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -52,9 +52,6 @@ code.block {
   padding: 8px;
   white-space: pre;
 }
-.uplot canvas {
-  background-color: var(--theme-stage);
-}
 .u-wrap {
   overflow-x: visible;
   overflow-y: hidden;


### PR DESCRIPTION
this adds elevation to the LineChart component. the linechart container
is now a surface, ensuring it appears at one level above the current
elevation. Because linecharts have borders now, this revealed a bug
where the legend of a chart would appear outside of the chart's borders.
To fix, we now dynamically assign the height of the row based on the
series in the row.