### PR TITLE
fix: Chart line filtering after zoom

### DIFF
--- a/src/DesignKit.tsx
+++ b/src/DesignKit.tsx
@@ -894,6 +894,7 @@ const ChartsSection: React.FC = () => {
     [4, 12],
   ]);
   const [timer, setTimer] = useState(line1Data.length);
+  const [showRandom, setShowRandom] = useState(false);
   useEffect(() => {
     let timeout: number | void;
     if (timer <= line1Data.length) {
@@ -979,6 +980,13 @@ const ChartsSection: React.FC = () => {
     name: 'training.Sci-Line',
   };
 
+  const randomLine: Serie[] = [...Array(20).keys()].map(() => ({
+    data: {
+      [XAxisDomain.Batches]: [...Array(11).keys()].map((b) => [b * 2, Math.random() * 60]),
+    },
+    name: `generated-random-serie-${Math.random() * 10000000000000}`,
+  }));
+
   const zeroline: Serie = {
     color: '#009BDE',
     data: {
@@ -1012,15 +1020,18 @@ const ChartsSection: React.FC = () => {
         </p>
       </SurfaceCard>
       <SurfaceCard title="Label options">
-        <p>A chart with two metrics, a title, a legend, an x-axis label, a y-axis label.</p>
+        <p>A chart with multiple metrics, a title, a legend, an x-axis label, a y-axis label.</p>
         <div>
           <Button onClick={randomizeLineData}>Randomize line data</Button>
           <Button onClick={streamLineData}>Stream line data</Button>
         </div>
+        <Checkbox checked={showRandom} onChange={(e) => setShowRandom(e.target.checked)}>
+          Show random generated data series
+        </Checkbox>
         <LineChart
           handleError={handleError}
           height={250}
-          series={[line1, line2]}
+          series={showRandom ? [line1, line2, ...randomLine] : [line1, line2]}
           showLegend={true}
           title="Sample"
         />

--- a/src/kit/LineChart.module.scss
+++ b/src/kit/LineChart.module.scss
@@ -47,27 +47,3 @@
   margin-bottom: var(--spacing-lg);
   padding-right: var(--spacing-sm);
 }
-.legendContainer {
-  margin-left: 35px;
-
-  .legendItem {
-    cursor: pointer;
-    display: inline-block;
-    font-family: var(--theme-font-family);
-    font-size: 12px;
-    font-weight: 500;
-    margin-right: var(--spacing-lg);
-
-    &.hideSeries {
-      opacity: 0.3;
-    }
-    .colorButton {
-      font-weight: bold;
-      margin-right: var(--spacing-md);
-    }
-
-    @supports (font-variation-settings: normal) {
-      font-family: var(--theme-font-family-var);
-    }
-  }
-}

--- a/src/kit/LineChart.tsx
+++ b/src/kit/LineChart.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useMemo, useState } from 'react';
+import React, { ReactNode, useMemo } from 'react';
 import { FixedSizeGrid, GridChildComponentProps } from 'react-window';
 import uPlot, { AlignedData, Plugin } from 'uplot';
 
@@ -91,8 +91,6 @@ export const LineChart: React.FC<LineChartProps> = ({
   const series = Loadable.ensureLoadable(propSeries).getOrElse([]);
   const isLoading = Loadable.isLoadable(propSeries) && Loadable.isNotLoaded(propSeries);
 
-  const [hiddenSeries, setHiddenSeries] = useState<Record<number, boolean>>({});
-
   const hasPopulatedSeries: boolean = useMemo(
     () => !!series.find((serie) => serie.data[xAxis]?.length),
     [series, xAxis],
@@ -117,9 +115,7 @@ export const LineChart: React.FC<LineChartProps> = ({
 
     series.forEach((serie, serieIndex) => {
       yValues[serieIndex] = {};
-      if (hiddenSeries[serieIndex]) {
-        return;
-      }
+
       (serie.data[xAxis] || []).forEach((pt) => {
         const xVal = pt[0];
         if ((xMin !== undefined && xVal < xMin) || (xMax !== undefined && xVal > xMax)) {
@@ -137,7 +133,7 @@ export const LineChart: React.FC<LineChartProps> = ({
     });
 
     return [xValues, ...yValuesArray];
-  }, [series, xAxis, hiddenSeries, xRange]);
+  }, [series, xAxis, xRange]);
 
   const xTickValues: uPlot.Axis.Values | undefined = useMemo(() => {
     if (xAxis === XAxisDomain.Time) {
@@ -205,7 +201,7 @@ export const LineChart: React.FC<LineChartProps> = ({
       },
       height: height - (hasPopulatedSeries ? 0 : 20),
       key,
-      legend: { show: false },
+      legend: { live: false, show: showLegend },
       plugins,
       scales: {
         x: {
@@ -257,6 +253,7 @@ export const LineChart: React.FC<LineChartProps> = ({
     propPlugins,
     focusedSeries,
     key,
+    showLegend,
   ]);
 
   return (
@@ -270,25 +267,6 @@ export const LineChart: React.FC<LineChartProps> = ({
         options={chartOptions}
         xAxis={xAxis}
       />
-      {showLegend && (
-        <div className={css.legendContainer}>
-          {hasPopulatedSeries ? (
-            series.map((s, idx) => (
-              <li
-                className={[css.legendItem, hiddenSeries[idx] ? css.hideSeries : ''].join(' ')}
-                key={idx}
-                onClick={() => setHiddenSeries({ ...hiddenSeries, [idx]: !hiddenSeries[idx] })}>
-                <span className={css.colorButton} style={{ color: seriesColors[idx] }}>
-                  &mdash;
-                </span>
-                {series[idx].name}
-              </li>
-            ))
-          ) : (
-            <li>&nbsp;</li>
-          )}
-        </div>
-      )}
     </div>
   );
 };

--- a/src/kit/internal/UPlot/UPlotChart.module.scss
+++ b/src/kit/internal/UPlot/UPlotChart.module.scss
@@ -3,6 +3,13 @@
   margin-bottom: 10px;
   margin-top: 10px;
   position: relative;
+
+  :global(.u-legend .u-marker) {
+    height: 2px;
+  }
+  :global(.u-legend) {
+    text-align: left;
+  }
 }
 .base.dark {
   :global(.u-select) {
@@ -14,6 +21,7 @@
   display: flex;
   height: 100%;
   justify-content: center;
+  min-height: inherit;
 }
 .download {
   border: 0;

--- a/src/kit/internal/UPlot/UPlotChart.tsx
+++ b/src/kit/internal/UPlot/UPlotChart.tsx
@@ -1,5 +1,5 @@
 import { isEqual } from 'lodash';
-import React, { RefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { RefObject, useCallback, useEffect, useMemo, useRef } from 'react';
 import { throttle } from 'throttle-debounce';
 import uPlot, { AlignedData } from 'uplot';
 
@@ -91,7 +91,6 @@ const UPlotChart: React.FC<Props> = ({
   xAxis,
 }: Props) => {
   const chartRef = useRef<uPlot>();
-  const [divHeight, setDivHeight] = useState((options?.height ?? 300) + 20);
   const { refObject, refCallback, size } = useResize();
   const classes = [css.base];
 
@@ -219,8 +218,6 @@ const UPlotChart: React.FC<Props> = ({
     const [width, height] = [size.width, options?.height || chartRef.current.height];
     if (chartRef.current.width === width && chartRef.current.height === height) return;
     chartRef.current.setSize({ height, width });
-    const container = refObject.current;
-    if (container && height) setDivHeight(height);
   }, [options?.height, refObject, size]);
 
   /*
@@ -247,7 +244,7 @@ const UPlotChart: React.FC<Props> = ({
   }, []);
 
   return (
-    <div className={classes.join(' ')} ref={refCallback} style={{ height: divHeight }}>
+    <div className={classes.join(' ')} ref={refCallback} style={{ minHeight: 250 }}>
       {allowDownload && <DownloadButton containerRef={refObject} experimentId={experimentId} />}
       {!hasData && !isLoading && (
         <div className={css.chartEmpty}>


### PR DESCRIPTION
Fix for [DET-1825](https://hpe-aiatscale.atlassian.net/browse/WEB-1825)

Test plan:
At the preview page, chart section.
For a chart with legends, zoom with drag and drop.
After the zoom, clicking on one of the legends should still hide/show the line.

Toggle the checkbox for `Show random generated data series`, resizing page should resize the chart properly.

Screenshot:
<img width="1437" alt="Screenshot 2023-12-06 at 4 25 32 PM" src="https://github.com/determined-ai/hew/assets/40620519/4574ceb0-6c25-4f0a-8428-eb50754419d3">


[DET-1825]: https://hpe-aiatscale.atlassian.net/browse/DET-1825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ