### PR TITLE
chore: Add MouseEvent arg to Modal handleSubmit

### DIFF
--- a/src/DesignKit.tsx
+++ b/src/DesignKit.tsx
@@ -82,7 +82,7 @@ import loremIpsum, { loremIpsumSentence } from 'utils/loremIpsum';
 import css from './DesignKit.module.scss';
 import ThemeToggle from './ThemeToggle';
 
-const noOp = () => {};
+const noOp = () => { };
 
 const ComponentTitles = {
   Accordion: 'Accordion',
@@ -3574,7 +3574,7 @@ const ValidationModalComponent: React.FC<{ value: string }> = ({ value }) => {
       submit={{
         disabled: !alias,
         handleError,
-        handler: handleSubmit,
+        handler: () => handleSubmit(false),
         text: 'Submit',
       }}
       title={value}>
@@ -4404,7 +4404,7 @@ const SplitPaneSection: React.FC = () => {
 
   const chart = (
     <LineChart
-      handleError={() => {}}
+      handleError={() => { }}
       height={250}
       series={[line1, line2]}
       showLegend={true}

--- a/src/DesignKit.tsx
+++ b/src/DesignKit.tsx
@@ -82,7 +82,7 @@ import loremIpsum, { loremIpsumSentence } from 'utils/loremIpsum';
 import css from './DesignKit.module.scss';
 import ThemeToggle from './ThemeToggle';
 
-const noOp = () => { };
+const noOp = () => {};
 
 const ComponentTitles = {
   Accordion: 'Accordion',
@@ -4404,7 +4404,7 @@ const SplitPaneSection: React.FC = () => {
 
   const chart = (
     <LineChart
-      handleError={() => { }}
+      handleError={() => {}}
       height={250}
       series={[line1, line2]}
       showLegend={true}

--- a/src/kit/Modal.tsx
+++ b/src/kit/Modal.tsx
@@ -35,7 +35,7 @@ export type ModalContext = {
 export interface ModalSubmitParams {
   disabled?: boolean;
   text: string;
-  handler: () => Promise<void> | void;
+  handler: (e: React.MouseEvent) => Promise<void> | void;
   onComplete?: () => Promise<void> | void;
   handleError: ErrorHandler;
   form?: string;
@@ -91,11 +91,11 @@ export const Modal: React.FC<ModalProps> = ({
     onClose?.();
   }, [setIsOpen, onClose]);
 
-  const handleSubmit = useCallback(async () => {
+  const handleSubmit = useCallback(async (e: React.MouseEvent) => {
     setIsSubmitting(true);
     try {
       await new Promise((resolve) => setTimeout(resolve)); // delays form validation until next event cycle to prevent validation conflicts
-      await submit?.handler();
+      await submit?.handler(e);
       setIsSubmitting(false);
       setIsOpen(false);
       await submit?.onComplete?.();

--- a/src/kit/Modal.tsx
+++ b/src/kit/Modal.tsx
@@ -91,25 +91,28 @@ export const Modal: React.FC<ModalProps> = ({
     onClose?.();
   }, [setIsOpen, onClose]);
 
-  const handleSubmit = useCallback(async (e: React.MouseEvent) => {
-    setIsSubmitting(true);
-    try {
-      await new Promise((resolve) => setTimeout(resolve)); // delays form validation until next event cycle to prevent validation conflicts
-      await submit?.handler(e);
-      setIsSubmitting(false);
-      setIsOpen(false);
-      await submit?.onComplete?.();
-    } catch (err) {
-      submit?.handleError(err, {
-        level: ErrorLevel.Error,
-        publicMessage: err instanceof Error ? err.message : '',
-        publicSubject: 'Could not submit form',
-        silent: false,
-        type: ErrorType.Server,
-      });
-      setIsSubmitting(false);
-    }
-  }, [submit, setIsOpen]);
+  const handleSubmit = useCallback(
+    async (e: React.MouseEvent) => {
+      setIsSubmitting(true);
+      try {
+        await new Promise((resolve) => setTimeout(resolve)); // delays form validation until next event cycle to prevent validation conflicts
+        await submit?.handler(e);
+        setIsSubmitting(false);
+        setIsOpen(false);
+        await submit?.onComplete?.();
+      } catch (err) {
+        submit?.handleError(err, {
+          level: ErrorLevel.Error,
+          publicMessage: err instanceof Error ? err.message : '',
+          publicSubject: 'Could not submit form',
+          silent: false,
+          type: ErrorType.Server,
+        });
+        setIsSubmitting(false);
+      }
+    },
+    [submit, setIsOpen],
+  );
 
   const stopEventPropagation = (e: AnyMouseEvent) => e.stopPropagation();
 


### PR DESCRIPTION
The `OnOK` method in the Antd modal takes [an event](https://ant.design/components/modal#api), this event is currently disregarded in Hew. One modal in Determined  actual does rely on this event, and other Hew users may want to also. This update updates Hew to expect this event. 