### PR TITLE
fix: Page screen shot path

### DIFF
--- a/scripts/designkit-screenshot.mjs
+++ b/scripts/designkit-screenshot.mjs
@@ -28,7 +28,7 @@ const browser = await chromium.launch();
 const page = await browser.newPage();
 await page.goto(`http://${address}:${port}${publicUrl}/design/?exclusive=true`);
 // take screenshots of each section
-const links = await page.locator('div ul a').all();
+const links = await page.locator('#main-nav ul a').all();
 if (links.length === 0) {
   console.error('WARNING: No sections found');
 }
@@ -40,7 +40,7 @@ for (const theme of THEMES) {
   for (const link of links) {
     await link.click();
     const title = await link.innerText();
-    const section = page.locator('div > article > article');
+    const section = page.locator('article');
     // playwright hangs if height is a non-int
     const height = Math.ceil((await section.boundingBox()).height);
     await page.setViewportSize({ height, width: 1280 });

--- a/src/DesignKit.tsx
+++ b/src/DesignKit.tsx
@@ -4568,7 +4568,7 @@ const DesignKit: React.FC<{
     <UIProvider priority="low" theme={theme} themeIsDark={themeIsDark}>
       <Spinner spinning={false}>
         <ElevationWrapper className={css.base} elevationOverride={0}>
-          <ElevationWrapper className={[css.nav, css.desktop].join(' ')}>
+          <ElevationWrapper className={[css.nav, css.desktop].join(' ')} id="main-nav">
             <ul className={css.sections}>
               <li>
                 <ThemeToggle mode={mode} onChange={onChangeMode} />


### PR DESCRIPTION
Since we replaced the `nav` tag with `ElevationWrapper` in demo page, path to get the screenshots need to be updated.

Note that this is only a temporary solution, we may want to change  `ElevationWrapper` to take dynamic tags.


Test plan:
Check `ci/circleci: test-screenshot`, "generate branch/upstream screenshot" section should not have "WARNING: No sections found"