### PR TITLE
Add modal props to replace useModal

### DIFF
--- a/src/DesignKit.module.scss
+++ b/src/DesignKit.module.scss
@@ -191,3 +191,10 @@ ul.sections {
 .title {
   font-weight: bold;
 }
+.modalFooter {
+  border-top: solid var(--theme-stroke-width) var(--theme-surface-border);
+  display: flex;
+  flex-direction: row;
+  padding-block: 8px;
+  padding-inline: 16px;
+}

--- a/src/DesignKit.tsx
+++ b/src/DesignKit.tsx
@@ -3498,6 +3498,19 @@ const LinksModalComponent: React.FC<{ value: string }> = ({ value }) => {
   );
 };
 
+const FooterModalComponent: React.FC<{ value: string }> = ({ value }) => {
+  const footer = (
+    <div className={css.modalFooter}>
+      <Button type="primary">Customized</Button>
+    </div>
+  );
+  return (
+    <Modal cancel footer={footer} title={value}>
+      <div>{value}</div>
+    </Modal>
+  );
+};
+
 const FormModalComponent: React.FC<{ value: string; fail?: boolean }> = ({ value, fail }) => {
   const { openToast } = useToast();
   const handleError = () =>
@@ -3595,6 +3608,7 @@ const ModalSection: React.FC = () => {
   const SmallModal = useModal(SmallModalComponent);
   const MediumModal = useModal(MediumModalComponent);
   const LargeModal = useModal(LargeModalComponent);
+  const FooterModal = useModal(FooterModalComponent);
   const FormModal = useModal(FormModalComponent);
   const FormFailModal = useModal(FormModalComponent);
   const LinksModal = useModal(LinksModalComponent);
@@ -3645,6 +3659,11 @@ const ModalSection: React.FC = () => {
           <Button onClick={FormFailModal.open}>Open Form Modal (Failure)</Button>
         </Row>
         <hr />
+        <strong>With custom footer</strong>
+        <Row wrap>
+          <Button onClick={FooterModal.open}>Open Footer Modal</Button>
+        </Row>
+        <hr />
         <strong>With form validation</strong>
         <Row wrap>
           <Button onClick={ValidationModal.open}>Open Modal with Form Validation</Button>
@@ -3659,6 +3678,7 @@ const ModalSection: React.FC = () => {
       <SmallModal.Component value={text} />
       <MediumModal.Component value={text} />
       <LargeModal.Component value={text} />
+      <FooterModal.Component value={text} />
       <FormModal.Component value={text} />
       <FormFailModal.Component fail value={text} />
       <LinksModal.Component value={text} />

--- a/src/kit/Modal.tsx
+++ b/src/kit/Modal.tsx
@@ -25,6 +25,8 @@ const modalWidths: { [key in ModalSize]: number } = {
   small: 358,
 };
 
+export type ModalCloseReason = 'ok' | 'cancel';
+
 export type Opener = Dispatch<SetStateAction<boolean>>;
 
 export type ModalContext = {
@@ -180,7 +182,11 @@ export const Modal: React.FC<ModalProps> = ({
 
 export const useModal = <ModalProps extends object>(
   Comp: React.FC<ModalProps>,
-): { close: (reason: string) => void; Component: React.FC<ModalProps>; open: () => void } => {
+): {
+  close: (reason: ModalCloseReason) => void;
+  Component: React.FC<ModalProps>;
+  open: () => void;
+} => {
   const [isOpen, setIsOpen] = useState(false);
   const handleOpen = React.useCallback(() => setIsOpen(true), []);
   const handleClose = React.useCallback(() => {

--- a/src/kit/Modal.tsx
+++ b/src/kit/Modal.tsx
@@ -180,9 +180,12 @@ export const Modal: React.FC<ModalProps> = ({
 
 export const useModal = <ModalProps extends object>(
   Comp: React.FC<ModalProps>,
-): { Component: React.FC<ModalProps>; open: () => void } => {
+): { close: (reason: string) => void; Component: React.FC<ModalProps>; open: () => void } => {
   const [isOpen, setIsOpen] = useState(false);
   const handleOpen = React.useCallback(() => setIsOpen(true), []);
+  const handleClose = React.useCallback(() => {
+    setIsOpen(false);
+  }, []);
 
   const Component = React.useCallback(
     (props: ModalProps) => {
@@ -195,5 +198,5 @@ export const useModal = <ModalProps extends object>(
     [Comp, isOpen],
   );
 
-  return { Component, open: handleOpen };
+  return { close: handleClose, Component, open: handleOpen };
 };

--- a/src/kit/Modal.tsx
+++ b/src/kit/Modal.tsx
@@ -52,6 +52,7 @@ interface ModalProps {
   cancel?: boolean;
   cancelText?: string;
   danger?: boolean;
+  footer?: React.ReactNode;
   footerLink?: React.ReactNode;
   headerLink?: React.ReactNode;
   icon?: IconName;
@@ -71,6 +72,7 @@ export const Modal: React.FC<ModalProps> = ({
   cancel,
   cancelText,
   danger,
+  footer,
   footerLink,
   headerLink,
   icon,
@@ -133,30 +135,32 @@ export const Modal: React.FC<ModalProps> = ({
         className={classes.join(' ')}
         closeIcon={<Icon name="close" size="small" title="Close modal" />}
         footer={
-          <div className={css.footer}>
-            <div className={css.footerLink}>{footerLink}</div>
-            <div className={css.buttons}>
-              {(cancel || cancelText) && (
-                <Button key="back" onClick={close}>
-                  {cancelText || DEFAULT_CANCEL_LABEL}
+          footer ?? (
+            <div className={css.footer}>
+              <div className={css.footerLink}>{footerLink}</div>
+              <div className={css.buttons}>
+                {(cancel || cancelText) && (
+                  <Button key="back" onClick={close}>
+                    {cancelText || DEFAULT_CANCEL_LABEL}
+                  </Button>
+                )}
+                <Button
+                  danger={danger}
+                  disabled={!!submit?.disabled}
+                  form={submit?.form}
+                  htmlType={submit?.form ? 'submit' : 'button'}
+                  key="submit"
+                  loading={isSubmitting}
+                  tooltip={
+                    submit?.disabled ? 'Address validation errors before proceeding' : undefined
+                  }
+                  type="primary"
+                  onClick={handleSubmit}>
+                  {submit?.text ?? 'OK'}
                 </Button>
-              )}
-              <Button
-                danger={danger}
-                disabled={!!submit?.disabled}
-                form={submit?.form}
-                htmlType={submit?.form ? 'submit' : 'button'}
-                key="submit"
-                loading={isSubmitting}
-                tooltip={
-                  submit?.disabled ? 'Address validation errors before proceeding' : undefined
-                }
-                type="primary"
-                onClick={handleSubmit}>
-                {submit?.text ?? 'OK'}
-              </Button>
+              </div>
             </div>
-          </div>
+          )
         }
         key={key}
         maskClosable={true}

--- a/src/kit/Modal.tsx
+++ b/src/kit/Modal.tsx
@@ -14,6 +14,7 @@ import Icon, { IconName } from 'kit/Icon';
 import Spinner from 'kit/Spinner';
 import { useTheme } from 'kit/Theme';
 import { ErrorHandler, ErrorLevel, ErrorType } from 'kit/utils/error';
+import { ValueOf } from 'kit/utils/types';
 
 import { type AnyMouseEvent } from './internal/types';
 import css from './Modal.module.scss';
@@ -25,7 +26,11 @@ const modalWidths: { [key in ModalSize]: number } = {
   small: 358,
 };
 
-export type ModalCloseReason = 'ok' | 'cancel';
+const ModalCloseReason = {
+  Cancel: 'cancel',
+  Ok: 'ok',
+};
+export type ModalCloseReason = ValueOf<typeof ModalCloseReason>;
 
 export type Opener = Dispatch<SetStateAction<boolean>>;
 


### PR DESCRIPTION
- Add custom footer prop and example
- Reimplement `ModalCloseReason`
- Modal returns `close: (reason: ModalCloseReason) => void;` to programmatically close a form (used in checkpointing to close one modal and open another)