### PR TITLE
access: add focus to Link and Accordion [WEB-1849]

### DIFF
--- a/src/kit/Accordion.module.scss
+++ b/src/kit/Accordion.module.scss
@@ -1,0 +1,7 @@
+.base:global(.ant-collapse-item) {
+  & > :global(.ant-collapse-header) {
+    &:focus-visible {
+      outline: 1px solid var(--theme-ix-on-active);
+    }
+  }
+}

--- a/src/kit/Accordion.module.scss
+++ b/src/kit/Accordion.module.scss
@@ -1,7 +1,7 @@
+@use '../utils' as *;
+
 .base:global(.ant-collapse-item) {
   & > :global(.ant-collapse-header) {
-    &:focus-visible {
-      outline: 1px solid var(--theme-ix-on-active);
-    }
+    @include focusable;
   }
 }

--- a/src/kit/Accordion.tsx
+++ b/src/kit/Accordion.tsx
@@ -4,6 +4,8 @@ import React from 'react';
 import { ConditionalWrapper } from 'kit/internal/ConditionalWrapper';
 import { useTheme } from 'kit/Theme';
 
+import css from './Accordion.module.scss';
+
 interface AccordionProps {
   title: React.ReactNode;
   children: React.ReactNode;
@@ -84,7 +86,7 @@ const Accordion: React.FC<AccordionProps> & { Group: typeof AccordionGroup } = (
   return (
     <ConditionalWrapper condition={!inGroup} wrapper={wrapper}>
       <Collapse.Panel
-        className={themeClass}
+        className={[css.base, themeClass].join(' ')}
         header={title}
         {...otherProps}
         {...panelProps}

--- a/src/kit/Link.module.scss
+++ b/src/kit/Link.module.scss
@@ -7,11 +7,8 @@
   span:nth-of-type(2) {
     margin-left: var(--spacing-xs);
   }
-  &:focus {
+  &:focus-visible {
     outline: 1px solid var(--theme-ix-on-active);
-  }
-  &:active {
-    outline: none;
   }
 }
 .inherit {

--- a/src/kit/Link.module.scss
+++ b/src/kit/Link.module.scss
@@ -1,16 +1,17 @@
 .base {
+  align-items: center;
   cursor: pointer;
+  display: inline-flex; // prevent wrapping behavior
+  width: fit-content;
 
-  .content {
-    align-items: center;
-    display: inline-flex; // prevent wrapping behavior
-
-    span:nth-of-type(2) {
-      margin-left: var(--spacing-xs);
-    }
+  span:nth-of-type(2) {
+    margin-left: var(--spacing-xs);
   }
   &:focus {
-    box-shadow: var(--theme-ix-active);
+    outline: 1px solid var(--theme-ix-on-active);
+  }
+  &:active {
+    outline: none;
   }
 }
 .inherit {

--- a/src/kit/Link.module.scss
+++ b/src/kit/Link.module.scss
@@ -1,3 +1,5 @@
+@use '../utils' as *;
+
 .base {
   align-items: center;
   cursor: pointer;
@@ -7,9 +9,8 @@
   span:nth-of-type(2) {
     margin-left: var(--spacing-xs);
   }
-  &:focus-visible {
-    outline: 1px solid var(--theme-ix-on-active);
-  }
+
+  @include focusable;
 }
 .inherit {
   color: inherit;

--- a/src/kit/Link.tsx
+++ b/src/kit/Link.tsx
@@ -33,10 +33,10 @@ const Link: React.FC<Props> = ({
 
   const content = useMemo(
     () => (
-      <div className={css.content}>
+      <>
         <span>{props.children}</span>
         {external ? <Icon name="popout" size="small" title="link" /> : null}
-      </div>
+      </>
     ),
     [props.children, external],
   );
@@ -51,6 +51,7 @@ const Link: React.FC<Props> = ({
       className={classes.join(' ')}
       href={href}
       rel={rel}
+      tabIndex={0}
       onClick={(e) => {
         e.stopPropagation();
         onClick?.(e);


### PR DESCRIPTION
Adds visible focus and tab-ability to the Link and Accordion components using `:focus-visible`