### PR TITLE
access: show typography tooltip on focus [WEB-1851]

### DIFF
--- a/src/kit/Typography.module.scss
+++ b/src/kit/Typography.module.scss
@@ -1,4 +1,5 @@
 /* stylelint-disable custom-property-pattern */
+@use '../utils' as *;
 
 :root {
   /* Title */
@@ -47,6 +48,8 @@
     font-size: var(--title-size-xs);
     line-height: var(--title-ln-xs);
   }
+
+  @include focusable;
 }
 .body {
   font-family: var(--theme-font-family);
@@ -64,6 +67,8 @@
     font-size: var(--body-size-s);
     line-height: var(--body-ln-s);
   }
+
+  @include focusable;
 }
 .label {
   font-family: var(--theme-font-family);
@@ -81,11 +86,15 @@
     font-size: var(--label-size-s);
     line-height: var(--label-ln-s);
   }
+
+  @include focusable;
 }
 .code {
   font-family: var(--theme-font-family-code);
   font-size: var(--body-size-default);
   line-height: var(--body-ln-default);
+
+  @include focusable;
 }
 :global(.ant-typography + h1.ant-typography),
 :global(h1.ant-typography),

--- a/src/kit/Typography.tsx
+++ b/src/kit/Typography.tsx
@@ -37,6 +37,7 @@ const getEllipsisConfig = (themeClass: string, children: ReactNode, truncate?: T
         ? {
             overlayClassName: themeClass,
             title: !isBoolean(truncate.tooltip) ? truncate.tooltip : children,
+            trigger: ['hover', 'focus'],
           }
         : false,
     };
@@ -62,7 +63,10 @@ export const Title: React.FC<TypographyProps> = ({
   const ellipsis = getEllipsisConfig(themeClass, children, truncate);
 
   return (
-    <Typography.Title className={classes.join(' ')} ellipsis={ellipsis}>
+    <Typography.Title
+      className={classes.join(' ')}
+      ellipsis={ellipsis}
+      tabIndex={truncate?.tooltip ? 0 : undefined}>
       {children}
     </Typography.Title>
   );
@@ -79,7 +83,10 @@ export const Body: React.FC<TypographyProps> = ({
   const classes = [getClassName('body', size), themeClass];
   const ellipsis = getEllipsisConfig(themeClass, children, truncate);
   return (
-    <Typography.Paragraph className={classes.join(' ')} ellipsis={ellipsis}>
+    <Typography.Paragraph
+      className={classes.join(' ')}
+      ellipsis={ellipsis}
+      tabIndex={truncate?.tooltip ? 0 : undefined}>
       {children}
     </Typography.Paragraph>
   );
@@ -104,7 +111,8 @@ export const Label: React.FC<LabelProps> = ({
       ellipsis={ellipsis}
       style={{
         color: inactive ? getThemeVar('statusInactive') : undefined,
-      }}>
+      }}
+      tabIndex={truncate?.tooltip ? 0 : undefined}>
       {children}
     </Typography.Text>
   );
@@ -118,7 +126,10 @@ export const Code: React.FC<CodeProps> = ({ children, truncate }: CodeProps) => 
   const classes = [getClassName('code'), themeClass];
   const ellipsis = getEllipsisConfig(themeClass, children, truncate);
   return (
-    <Typography.Paragraph className={classes.join(' ')} ellipsis={ellipsis}>
+    <Typography.Paragraph
+      className={classes.join(' ')}
+      ellipsis={ellipsis}
+      tabIndex={truncate?.tooltip ? 0 : undefined}>
       {children}
     </Typography.Paragraph>
   );

--- a/src/utils/_index.scss
+++ b/src/utils/_index.scss
@@ -1,0 +1,5 @@
+@mixin focusable {
+  &:focus-visible {
+    outline: 1px solid var(--theme-ix-on-active);
+  }
+}


### PR DESCRIPTION
Adds keyboard focusability to Typography elements if `truncate?.tooltip` is not undefined. Confirmed that truncated content is read by macOS VoiceOver screenreader. I also added a `utils/_index.scss` file that can be used to store reusable SCSS functions/mixins.