### PR TITLE
access: focus dropdown menu with keyboard [WEB-1844]

### DIFF
--- a/src/DesignKit.tsx
+++ b/src/DesignKit.tsx
@@ -1275,6 +1275,17 @@ const DropdownSection: React.FC = () => {
     { type: 'divider' },
     { key: 'archive', label: 'Archive' },
   ];
+  const menuWithGroup: MenuItem[] = [
+    ...menu,
+    {
+      children: [
+        { key: 'group-start', label: 'Start' },
+        { key: 'group-stop', label: 'Stop' },
+      ],
+      label: 'Group',
+      type: 'group',
+    },
+  ];
   const menuWithDanger: MenuItem[] = [...menu, { danger: true, key: 'delete', label: 'Delete' }];
   const menuWithDisabled: MenuItem[] = [
     ...menu,
@@ -1293,7 +1304,7 @@ const DropdownSection: React.FC = () => {
       </SurfaceCard>
       <SurfaceCard title="Usage">
         <strong>Dropdown variations</strong>
-        <Space>
+        <Row wrap>
           <Dropdown menu={menu}>
             <Button>Dropdown with menu</Button>
           </Dropdown>
@@ -1305,11 +1316,14 @@ const DropdownSection: React.FC = () => {
           <Dropdown disabled menu={menu}>
             <Button>Disabled Dropdown menu</Button>
           </Dropdown>
-        </Space>
+        </Row>
         <strong>Dropdown menu variations</strong>
-        <Space>
+        <Row wrap>
           <Dropdown menu={menuWithDivider}>
             <Button>Dropdown menu with a Divider</Button>
+          </Dropdown>
+          <Dropdown menu={menuWithGroup}>
+            <Button>Dropdown menu with a Group</Button>
           </Dropdown>
           <Dropdown menu={menuWithDanger}>
             <Button>Dropdown menu with Dangerous Option</Button>
@@ -1317,7 +1331,7 @@ const DropdownSection: React.FC = () => {
           <Dropdown menu={menuWithDisabled}>
             <Button>Dropdown menu with Disabled Option</Button>
           </Dropdown>
-        </Space>
+        </Row>
       </SurfaceCard>
     </ComponentSection>
   );

--- a/src/kit/Dropdown.module.scss
+++ b/src/kit/Dropdown.module.scss
@@ -1,3 +1,5 @@
+@use '../utils' as *;
+
 :global(.ant-dropdown > .ant-dropdown-menu),
 :global(.ant-popover-content > .ant-popover-inner) {
   border: solid var(--theme-stroke-width) var(--theme-float-border);
@@ -9,4 +11,14 @@
 }
 :global(.ant-popover) {
   padding-top: 0;
+}
+:global(.ant-dropdown-menu-item) {
+  :global(.ant-dropdown-menu-title-content) {
+    flex: none !important;
+  }
+
+  @include focusable;
+}
+:global(.ant-dropdown-menu-item-group-title) {
+  display: flex;
 }

--- a/src/kit/List.tsx
+++ b/src/kit/List.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from 'react';
 
 import Button from 'kit/Button';
 import Column from 'kit/Column';
-import Dropdown from 'kit/Dropdown';
+import Dropdown, { MenuItem } from 'kit/Dropdown';
 import Icon, { IconName } from 'kit/Icon';
 import { ElevationWrapper } from 'kit/internal/Elevation';
 import { AnyMouseEventHandler } from 'kit/internal/types';
@@ -31,7 +31,7 @@ export interface ListItem {
   onClick?: AnyMouseEventHandler;
 }
 
-const getMenuOptions = (menu?: Action[]) => {
+const getMenuOptions = (menu?: Action[]): MenuItem[] | undefined => {
   return menu?.map((m, idx) => {
     return {
       key: idx,


### PR DESCRIPTION
Dropdown menu should be usable with keyboard following these steps:

1. Tab to dropdown button
2. Enter to open menu
3. Tab to dropdown menu
4. Enter to interior of menu
5. Arrow keys to select desired option
6. Enter to submit option