### PR TITLE
fix: Add themeClass to Pivot popup

### DIFF
--- a/src/kit/Pivot.tsx
+++ b/src/kit/Pivot.tsx
@@ -58,7 +58,7 @@ const Pivot: React.FC<PivotProps> = ({ type = 'primary', items, ...props }) => {
       })),
     [items, nextElevation],
   );
-  return <Tabs className={classes.join(' ')} items={elevatedItems} type={tabType} {...props} />;
+  return <Tabs className={classes.join(' ')} popupClassName={themeClass} items={elevatedItems} type={tabType} {...props} />;
 };
 
 export default Pivot;


### PR DESCRIPTION
The `themeClass` is now appropriately applied to the `Pivot` component. 

Ticket: https://hpe-aiatscale.atlassian.net/browse/WEB-1892

Test Plan:

1. Navigate to Pivot section on our examples page.
2. Decrease your screen size until the overflow menu toggle appears.
3. Open the overflow menu and ensure the font matches the rest of the application. 