### PR TITLE
chore: Make Progress Bar Accessible [WEB-1845]

### DIFF
--- a/src/kit/Progress.tsx
+++ b/src/kit/Progress.tsx
@@ -67,15 +67,15 @@ const Progress: React.FC<Props> = ({
               .map((part, idx) => (
                 <Tooltip content={showTooltips && part.label} key={idx}>
                   <li
+                    aria-label={part.label}
+                    aria-valuemax={1}
+                    aria-valuemin={0}
+                    aria-valuetext={`${part.percent * 100} percent`}
+                    role="progressbar"
                     style={{
                       ...partStyle(part),
                       cursor: showTooltips && part.label ? 'pointer' : '',
                     }}
-                    aria-label={part.label}
-                    aria-valuemin={0}
-                    aria-valuemax={1}
-                    aria-valuetext={`${part.percent * 100} percent`}
-                    role='progressbar'
                   />
                 </Tooltip>
               ))}

--- a/src/kit/Progress.tsx
+++ b/src/kit/Progress.tsx
@@ -67,10 +67,7 @@ const Progress: React.FC<Props> = ({
               .map((part, idx) => (
                 <Tooltip content={showTooltips && part.label} key={idx}>
                   <li
-                    aria-label={part.label}
-                    aria-valuemax={1}
-                    aria-valuemin={0}
-                    aria-valuetext={`${part.percent * 100} percent`}
+                    aria-label={`${part.label} ${part.percent * 100} percent`}
                     role="progressbar"
                     style={{
                       ...partStyle(part),

--- a/src/kit/Progress.tsx
+++ b/src/kit/Progress.tsx
@@ -71,6 +71,11 @@ const Progress: React.FC<Props> = ({
                       ...partStyle(part),
                       cursor: showTooltips && part.label ? 'pointer' : '',
                     }}
+                    aria-label={part.label}
+                    aria-valuemin={0}
+                    aria-valuemax={1}
+                    aria-valuetext={`${part.percent * 100} percent`}
+                    role='progressbar'
                   />
                 </Tooltip>
               ))}


### PR DESCRIPTION
This is part of the work for WEB-1845. This makes our progress bar accessible. 

Test Plan:
1. Install a Screen Reader, if you are on Chrome I suggest: https://chromewebstore.google.com/detail/screen-reader/kgejglhpjiefppelpmljglcjbhoiplfn
2. With the screen reader enabled navigate to the `Progress` section on the examples page. Ensure the screen reader appropriately dictates the progress bar. For example if you click on the a part of the progress bar as such: 

![E43ED6AC-B446-4B0C-89D4-C0F36F4CD3F4](https://github.com/determined-ai/hew/assets/103522725/b56ac3ae-a67c-4870-b24b-6a2d82dd5643)

The screen reader should dictate: "Progress bar, Plan A, 50%" or similar. 

 ~~note: this likely will not work until https://github.com/determined-ai/hew/pull/85 is merged in.~~