### PR TITLE
fix: Wrap longer URLs in Toast [WEB-1769]

### DIFF
--- a/src/DesignKit.tsx
+++ b/src/DesignKit.tsx
@@ -3469,6 +3469,15 @@ const ToastSection: React.FC = () => {
           <Button onClick={() => openToast({ severity: 'Info', title: 'Compact notification' })}>
             Open a toast without description
           </Button>
+          <Button
+            onClick={() =>
+              openToast({
+                severity: 'Error',
+                title: 'http://localhost:3000/det/clusters/historical-usage',
+              })
+            }>
+            Open a toast with long URL title
+          </Button>
         </Row>
       </SurfaceCard>
     </ComponentSection>

--- a/src/kit/Toast.module.scss
+++ b/src/kit/Toast.module.scss
@@ -1,6 +1,7 @@
 .message {
   display: flex;
-  word-break: break-word;
+  overflow-wrap: anywhere;
+  word-break: normal;
 
   span {
     margin-right: var(--spacing-xs);

--- a/src/kit/Toast.module.scss
+++ b/src/kit/Toast.module.scss
@@ -1,5 +1,6 @@
 .message {
   display: flex;
+  word-break: break-word;
 
   span {
     margin-right: var(--spacing-xs);

--- a/src/kit/Toast.tsx
+++ b/src/kit/Toast.tsx
@@ -86,7 +86,7 @@ export const makeToast = ({
       <ToastThemeProvider>
         <div className={css.message}>
           <Icon decorative name={getIconName(severity)} />
-          {title}
+          <span>{title}</span>
         </div>
       </ToastThemeProvider>
     ),


### PR DESCRIPTION
Uses CSS in Toast to split URL titles, and break on whitespace if available.
Reference: https://developer.mozilla.org/en-US/docs/Web/CSS/word-break (replacement for `word-break: break-word`)

<img width="421" alt="Screen Shot 2023-12-21 at 11 12 44 AM" src="https://github.com/determined-ai/hew/assets/643918/bfad7ae5-a7e7-458e-bc91-edfaa0d67a6f">

## Testing

- In the new DesignKit demo, there is some overlap with the title and close button [x] ; which I don't see in Determined
- Sample code to test in Determined:
 
```javascript
import { useToast } from 'hew/Toast';
...
const { openToast } = useToast();
...
      openToast({ duration: 30000, severity: 'Error', title: 'aaaaaaaa.atlassian.net/jira/software/c/projects/WEB/boards/36/backlog' });
      openToast({ duration: 30000, severity: 'Error', title: 'overview overview overview overview overview overview overview'});
```