### PR TITLE
access: add autocomplete to inputs [WEB-1846]

### DIFF
--- a/src/kit/Input.tsx
+++ b/src/kit/Input.tsx
@@ -1,4 +1,4 @@
-import { Input as AntdInput, InputRef as AntdInputRef } from 'antd';
+import { Input as AntdInput, InputRef as AntdInputRef, Space } from 'antd';
 import React, {
   CSSProperties,
   FC,
@@ -42,6 +42,7 @@ interface InputProps {
 }
 
 interface TextAreaProps {
+  autoComplete?: string;
   disabled?: boolean;
   onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
   placeholder?: string;
@@ -50,6 +51,7 @@ interface TextAreaProps {
 }
 
 interface PasswordProps {
+  autoComplete?: string;
   autoFocus?: boolean;
   disabled?: boolean;
   placeholder?: string;
@@ -88,12 +90,16 @@ type Input = ForwardRefExoticComponent<InputProps & RefAttributes<AntdInputRef>>
   TextArea: ForwardRefExoticComponent<TextAreaProps & RefAttributes<AntdInputRef>>;
 };
 
-const Group: FC<GroupProps> = (props: GroupProps) => {
+const Group: FC<GroupProps> = ({ compact = true, ...props }: GroupProps) => {
   const {
     themeSettings: { className },
   } = useTheme();
   const classes = props?.className ? className.concat(' ', props.className) : className;
-  return <AntdInput.Group {...props} className={classes} />;
+  return compact ? (
+    <Space.Compact {...props} className={classes} />
+  ) : (
+    <Space {...props} className={classes} />
+  );
 };
 
 Input.Group = Group;


### PR DESCRIPTION
Adds `autoComplete` to Input.TextArea and Input.Password. Noticed that [Input.Group was deprecated](https://ant.design/components/input#components-input-demo-group) so I replaced it with their suggested alternative. AntD's InputNumber component doesn't seem to support `autoComplete`, so I didn't change anything there.