### PR TITLE
fix: dropdown should not be truncated

### DIFF
--- a/src/kit/Dropdown.tsx
+++ b/src/kit/Dropdown.tsx
@@ -108,7 +108,6 @@ const Dropdown: React.FC<Props> = ({
     <AntdPopover
       className={className}
       content={content}
-      getPopupContainer={(node) => node}
       open={open}
       overlayClassName={themeClass}
       overlayStyle={overlayStyle}
@@ -122,7 +121,6 @@ const Dropdown: React.FC<Props> = ({
     <AntDropdown
       className={className}
       disabled={disabled}
-      getPopupContainer={(node) => node}
       menu={antdMenu}
       open={open}
       overlayClassName={themeClass}


### PR DESCRIPTION
Fix the issue that the dropdown is truncated when using in tables. 
Ticket: https://hpe-aiatscale.atlassian.net/browse/WEB-1907

![1B3EBBD1-9EBE-46E9-A439-5DB0A14BD610](https://github.com/determined-ai/hew/assets/40620519/3ca99ed1-b191-48e6-92fe-e0082b1917f6)
