### PR TITLE
feat: Resize Splitpane with keyboard

### DIFF
--- a/src/kit/SplitPane.module.scss
+++ b/src/kit/SplitPane.module.scss
@@ -25,6 +25,9 @@
       margin: var(--spacing-none) auto;
       width: var(--theme-stroke-width);
     }
+    &:focus-visible {
+      outline: var(--theme-ix-on-active) auto 1px;
+    }
   }
   &.showRightPane > * {
     display: block;

--- a/src/kit/SplitPane.tsx
+++ b/src/kit/SplitPane.tsx
@@ -102,6 +102,25 @@ const SplitPane: React.FC<Props> = ({
     return () => document.removeEventListener('mouseup', handleDragStop);
   }, [width, isDragging, onChange, throttledOnChange]);
 
+  useEffect(() => {
+    const KEYBOARD_RESIZE_INTERVAL = 4;
+    const onPressKey = (event: KeyboardEvent) => {
+      if (document.activeElement === handle.current) {
+        if (event.key === 'ArrowLeft') {
+          setWidth((width) => width - KEYBOARD_RESIZE_INTERVAL);
+          throttledOnChange?.(width - KEYBOARD_RESIZE_INTERVAL);
+        }
+        if (event.key === 'ArrowRight') {
+          setWidth((width) => width + KEYBOARD_RESIZE_INTERVAL);
+          throttledOnChange?.(width + KEYBOARD_RESIZE_INTERVAL);
+        }
+      }
+    };
+    window.addEventListener('keydown', onPressKey, true);
+
+    return () => window.removeEventListener('keydown', onPressKey, true);
+  }, [throttledOnChange, width]);
+
   const hideHandle = hidePane !== undefined;
 
   const leftPaneStyle = {
@@ -121,6 +140,7 @@ const SplitPane: React.FC<Props> = ({
         className={css.handle}
         ref={handle}
         style={{ display: hideHandle ? 'none' : 'initial' }}
+        tabIndex={0}
       />
       <div className={css.rightBox}>{rightPane}</div>
     </div>


### PR DESCRIPTION
Test plan:

At the Splitpane section, tab into the Splitpane handle, there should be a visible outline indicates the handle has been focused.
<img width="1669" alt="Screenshot 2024-01-09 at 12 43 06 PM" src="https://github.com/determined-ai/hew/assets/40620519/5c53e12f-5254-4f21-89a9-232057b99ea1">
Click left/right key, the Splitpane should resize accordingly. 


[WEB-1848](https://hpe-aiatscale.atlassian.net/browse/WEB-1848)

[WEB-1848]: https://hpe-aiatscale.atlassian.net/browse/WEB-1848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ