### PR TITLE
fix: InputShortcut blur on tab press [WEB-1853]

### DIFF
--- a/src/kit/InputShortcut.tsx
+++ b/src/kit/InputShortcut.tsx
@@ -84,6 +84,7 @@ const InputShortcut: React.FC<InputShortcutProps> = ({
 
   const onKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
+      e.stopPropagation();
       e.preventDefault();
       const keys: KeyboardShortcut = {
         alt: e.altKey,
@@ -92,7 +93,12 @@ const InputShortcut: React.FC<InputShortcutProps> = ({
         meta: e.metaKey,
         shift: e.shiftKey,
       };
-      value ? onChange?.(keys) : setInputValue(shortcutToString(keys));
+
+      if (shortcutToString(keys) === 'TAB') {
+        inputRef?.current?.blur(); // TAB key should blur for keyboard accessibility
+      } else {
+        value ? onChange?.(keys) : setInputValue(shortcutToString(keys));
+      }
     },
     [onChange, value],
   );


### PR DESCRIPTION
for [WEB-1853](https://hpe-aiatscale.atlassian.net/browse/WEB-1853)

Adds the ability to blur `InputShortcut` by pressing TAB key.
Also adding `stopPropagation` call to avoid triggering existing keyboard shortcuts while using this component.

[WEB-1853]: https://hpe-aiatscale.atlassian.net/browse/WEB-1853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ