### PR TITLE
fix: Tags, keyboard accesibility [WEB-1852]

### DIFF
--- a/src/kit/Link.tsx
+++ b/src/kit/Link.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 
 import { useTheme } from 'kit/Theme';
 
@@ -9,7 +9,6 @@ interface Props {
   children?: React.ReactNode;
   external?: boolean; // Only used to control external link style
   onClick?: React.MouseEventHandler<HTMLAnchorElement>;
-  onKeyDown?: React.KeyboardEventHandler;
   href?: string;
   rel?: string;
   disabled?: boolean;
@@ -23,7 +22,6 @@ const Link: React.FC<Props> = ({
   rel,
   disabled,
   external,
-  onKeyDown,
   ...props
 }: Props) => {
   const {
@@ -32,6 +30,11 @@ const Link: React.FC<Props> = ({
   const classes = [css.base, themeClass];
   if (disabled) classes.push(css.disabled);
   if (size) classes.push(css[size]);
+
+  const ref = useRef<HTMLAnchorElement>(null);
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') ref.current?.click();
+  };
 
   const content = useMemo(
     () => (
@@ -52,6 +55,7 @@ const Link: React.FC<Props> = ({
       aria-label={href}
       className={classes.join(' ')}
       href={href}
+      ref={ref}
       rel={rel}
       tabIndex={0}
       onClick={(e) => {

--- a/src/kit/Link.tsx
+++ b/src/kit/Link.tsx
@@ -9,6 +9,7 @@ interface Props {
   children?: React.ReactNode;
   external?: boolean; // Only used to control external link style
   onClick?: React.MouseEventHandler<HTMLAnchorElement>;
+  onKeyDown?: React.KeyboardEventHandler;
   href?: string;
   rel?: string;
   disabled?: boolean;
@@ -22,6 +23,7 @@ const Link: React.FC<Props> = ({
   rel,
   disabled,
   external,
+  onKeyDown,
   ...props
 }: Props) => {
   const {
@@ -55,7 +57,8 @@ const Link: React.FC<Props> = ({
       onClick={(e) => {
         e.stopPropagation();
         onClick?.(e);
-      }}>
+      }}
+      onKeyDown={onKeyDown}>
       {content}
     </a>
   );

--- a/src/kit/Tags.tsx
+++ b/src/kit/Tags.tsx
@@ -89,8 +89,8 @@ const Tags: React.FC<Props> = ({ compact, disabled = false, ghost, tags, onActio
   ) => {
     const newTag = (e.target as HTMLInputElement).value.trim();
     const oldTag = previousValue?.trim();
-    if (newTag) {
-      if (oldTag && newTag !== oldTag) {
+    if (newTag && newTag !== oldTag) {
+      if (oldTag) {
         onAction?.(TagAction.Update, newTag, tagID);
       } else {
         onAction?.(TagAction.Add, newTag);

--- a/src/kit/Tags.tsx
+++ b/src/kit/Tags.tsx
@@ -55,16 +55,19 @@ const Tags: React.FC<Props> = ({ compact, disabled = false, ghost, tags, onActio
     [onAction, disabled],
   );
 
-  const handleEdit = useCallback((htmlId: string, index: number) => {
-    if (disabled) return;
-    const element = document.getElementById(htmlId);
-    const rect = element?.getBoundingClientRect();
-    setState((state) => ({
-      ...state,
-      editInputIndex: index,
-      inputWidth: rect?.width ?? state.inputWidth,
-    }));
-  }, [disabled]);
+  const handleEdit = useCallback(
+    (htmlId: string, index: number) => {
+      if (disabled) return;
+      const element = document.getElementById(htmlId);
+      const rect = element?.getBoundingClientRect();
+      setState((state) => ({
+        ...state,
+        editInputIndex: index,
+        inputWidth: rect?.width ?? state.inputWidth,
+      }));
+    },
+    [disabled],
+  );
 
   const handleTagPlus = useCallback(() => {
     setState((state) => ({ ...state, inputVisible: true }));
@@ -140,12 +143,8 @@ const Tags: React.FC<Props> = ({ compact, disabled = false, ghost, tags, onActio
           if (compact && !showMore && index >= COMPACT_MAX_THRESHOLD) {
             if (index > COMPACT_MAX_THRESHOLD) return null;
             return (
-              <Link
-                key="more"
-                onClick={() => setShowMore(true)}>
-                <span className={css.showMore}>
-                  +{tags.length - COMPACT_MAX_THRESHOLD} more
-                </span>
+              <Link key="more" onClick={() => setShowMore(true)}>
+                <span className={css.showMore}>+{tags.length - COMPACT_MAX_THRESHOLD} more</span>
               </Link>
             );
           }

--- a/src/kit/Tags.tsx
+++ b/src/kit/Tags.tsx
@@ -142,10 +142,7 @@ const Tags: React.FC<Props> = ({ compact, disabled = false, ghost, tags, onActio
             return (
               <Link
                 key="more"
-                onClick={() => setShowMore(true)}
-                onKeyDown={(e: React.KeyboardEvent) => {
-                  if (e.key === 'Enter') setShowMore(true);
-                }}>
+                onClick={() => setShowMore(true)}>
                 <span className={css.showMore}>
                   +{tags.length - COMPACT_MAX_THRESHOLD} more
                 </span>


### PR DESCRIPTION
- Adds `tabIndex` to allow navigation with Tab key
- Adds event handlers to Add and Edit Tags with Enter key and Delete Tags with Backspace
- Also changing Link to always fire click handler on Enter press
- Also adjusting Tag edit to prevent creating duplicates when no exiting without change