### PR TITLE
fix: Scientific notation / null tick marks in Charts

### DIFF
--- a/src/kit/LineChart.tsx
+++ b/src/kit/LineChart.tsx
@@ -29,8 +29,8 @@ const getScientificNotationTickValues: uPlot.Axis['values'] = (_self, rawValues)
     (val) => val > 9_999 || val < -9_999 || (0 < val && val < 0.0001) || (-0.0001 < val && val < 0),
   );
   return useNotation
-    ? rawValues.map((val) => (val === 0 ? val : val.toExponential(2)))
-    : rawValues.map((val) => Number(val.toFixed(2)));
+    ? rawValues.map((val) => (val ? val.toExponential(2) : val))
+    : rawValues.map((val) => (val ? Number(val.toFixed(2)) : val));
 };
 
 /**


### PR DESCRIPTION
Chart scientific notation ticks did not handle null values; this is noticeable when switching to Log scale in experiments with multiple metrics:

On Latest-Main: `/det/experiments/5614/metrics`
On GCloud: `/det/experiments/2891/metrics`

<img width="460" alt="Screen Shot 2024-01-17 at 4 56 00 PM" src="https://github.com/determined-ai/hew/assets/643918/43f7d6d2-a3e3-4f6e-bbd5-2fc5b5abf1f1">

Fix is to pass through 0, null, and other falsey values instead of attempting to use toFixed or scientific notation