### PR TITLE
add npm publish action

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -39,11 +39,11 @@ jobs:
         name: "bump version"
         env:
           VERSION: ${{ inputs.bump_level }}
-        run: "npm version $VERSION"
+        run: "npm version $VERSION --dry-run"
       - if: ${{ inputs.bump_level == "custom" }}
         name: "custom version bump"
         env:
           VERSION ${{ inputs.custom_bump_level }}
-        run: "[ -n $VERSION ] && npm version $VERSION || (echo 'custom version indicated but not set' && false)"
+        run: "[ -n $VERSION ] && npm version $VERSION --dry-run || (echo 'custom version indicated but not set' && false)"
       - name: "publishing"
-        run: "npm publish"
+        run: "npm publish --dry-run"

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -26,7 +26,7 @@ jobs:
         run: "echo 'custom version indicated but not set' && exit 1"
   build-and-publish:
     needs: [validate-input]
-    uses: determined-ai/publish-to-npm-action/.github/workflows/publish-to-npm.yml@v4
+    uses: determined-ai/publish-to-npm-action/.github/workflows/publish-to-npm.yml@v0
     with:
       bump_level: ${{ startsWith(inputs.bump_level, 'custom') && inputs.custom_bump_level || inputs.bump_level }}
       npm_token: ${{ secrets.NPM_CLASSIC_TOKEN }}

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -1,0 +1,49 @@
+name: publish-to-npm
+run-name: ${{ github.actor }} is publishing to npm
+on:
+  workflow-dispatch:
+    inputs:
+      bump_level:
+        description: type of version bump
+        type: choice
+        default: patch
+        required: true
+        options:
+          - patch
+          - minor
+          - major
+          - custom (use custom_bump_level)
+      custom_bump_level:
+        description: version to bump to
+        type: string
+
+jobs:
+  build-and-publish:
+    name: build and publish package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: './.nvmrc'
+          cache: npm
+      - name: "install deps"
+        run: npm ci
+      - name: "export login token"
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_CLASSIC_TOKEN }}
+        run: "echo //registry.npmjs.org/:_authToken=$NPM_TOKEN > ./.npmrc"
+      - if: ${{ inputs.bump_level != "custom" }}
+        name: "bump version"
+        env:
+          VERSION: ${{ inputs.bump_level }}
+        run: "npm version $VERSION"
+      - if: ${{ inputs.bump_level == "custom" }}
+        name: "custom version bump"
+        env:
+          VERSION ${{ inputs.custom_bump_level }}
+        run: "[ -n $VERSION ] && npm version $VERSION || (echo 'custom version indicated but not set' && false)"
+      - name: "publishing"
+        run: "npm publish"

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -18,13 +18,15 @@ on:
         type: string
 
 jobs:
-  build-and-publish:
+  validate-input:
     name: build and publish package
     runs-on: ubuntu-latest
     steps:
       - if: ${{ startsWith(inputs.bump_level, 'custom') && inputs.custom_bump_level == '' }}
         run: "echo 'custom version indicated but not set' && exit 1"
-      - uses: determined-ai/publish-to-npm-action/.github/workflows/publish-to-npm@v4
-        with:
-          bump_level: ${{ startsWith(inputs.bump_level, 'custom') && inputs.custom_bump_level || inputs.bump_level }}
-          npm_token: ${{ secrets.NPM_CLASSIC_TOKEN }}
+  build-and-publish:
+    needs: [validate-input]
+    uses: determined-ai/publish-to-npm-action/.github/workflows/publish-to-npm@v4
+    with:
+      bump_level: ${{ startsWith(inputs.bump_level, 'custom') && inputs.custom_bump_level || inputs.bump_level }}
+      npm_token: ${{ secrets.NPM_CLASSIC_TOKEN }}

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -29,4 +29,5 @@ jobs:
     uses: determined-ai/publish-to-npm-action/.github/workflows/publish-to-npm.yml@v0
     with:
       bump_level: ${{ startsWith(inputs.bump_level, 'custom') && inputs.custom_bump_level || inputs.bump_level }}
-      npm_token: ${{ secrets.NPM_CLASSIC_TOKEN }}
+    secrets:
+      NPM_CLASSIC_TOKEN: ${{ secrets.NPM_CLASSIC_TOKEN }}

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -22,28 +22,9 @@ jobs:
     name: build and publish package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - if: ${{ startsWith(inputs.bump_level, 'custom') && inputs.custom_bump_level == '' }}
+        run: "echo 'custom version indicated but not set' && exit 1"
+      - uses: determined-ai/publish-to-npm-action/.github/workflows/publish-to-npm@v4
         with:
-          fetch-depth: 0
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: './.nvmrc'
-          cache: npm
-      - name: "install deps"
-        run: npm ci
-      - name: "export login token"
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_CLASSIC_TOKEN }}
-        run: "echo //registry.npmjs.org/:_authToken=$NPM_TOKEN > ./.npmrc"
-      - if: ${{ ! startsWith(inputs.bump_level, 'custom') }}
-        name: "bump version"
-        env:
-          VERSION: ${{ inputs.bump_level }}
-        run: "npm version $VERSION --dry-run"
-      - if: ${{ startsWith(inputs.bump_level, 'custom') }}
-        name: "custom version bump"
-        env:
-          VERSION: ${{ inputs.custom_bump_level }}
-        run: "[ -n $VERSION ] && npm version $VERSION --dry-run || (echo 'custom version indicated but not set' && false)"
-      - name: "publishing"
-        run: "npm publish --dry-run"
+          bump_level: ${{ startsWith(inputs.bump_level, 'custom') && inputs.custom_bump_level || inputs.bump_level }}
+          npm_token: ${{ secrets.NPM_CLASSIC_TOKEN }}

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -26,7 +26,7 @@ jobs:
         run: "echo 'custom version indicated but not set' && exit 1"
   build-and-publish:
     needs: [validate-input]
-    uses: determined-ai/publish-to-npm-action/.github/workflows/publish-to-npm@v4
+    uses: determined-ai/publish-to-npm-action/.github/workflows/publish-to-npm.yml@v4
     with:
       bump_level: ${{ startsWith(inputs.bump_level, 'custom') && inputs.custom_bump_level || inputs.bump_level }}
       npm_token: ${{ secrets.NPM_CLASSIC_TOKEN }}

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -27,9 +27,8 @@ jobs:
   build-and-publish:
     name: build and publish
     needs: [validate-input]
-    uses: determined-ai/publish-to-npm-action/.github/workflows/publish-to-npm.yml@v0
+    uses: determined-ai/publish-to-npm-action/.github/workflows/publish-to-npm.yml@main
     with:
       bump_level: ${{ startsWith(inputs.bump_level, 'custom') && inputs.custom_bump_level || inputs.bump_level }}
-      github_token: ${{ github.token }}
     secrets:
       NPM_CLASSIC_TOKEN: ${{ secrets.NPM_CLASSIC_TOKEN }}

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
           node-version-file: './.nvmrc'

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -38,12 +38,12 @@ jobs:
       - env:
           BUMP_LEVEL: ${{ inputs.bump_level }}
         run: "echo $BUMP_LEVEL"
-      - if: ${{ inputs.bump_level != "custom" }}
+      - if: ${{ inputs.bump_level != 'custom' }}
         name: "bump version"
         env:
           VERSION: ${{ inputs.bump_level }}
         run: "npm version $VERSION --dry-run"
-      - if: ${{ inputs.bump_level == "custom" }}
+      - if: ${{ inputs.bump_level == 'custom' }}
         name: "custom version bump"
         env:
           VERSION: ${{ inputs.custom_bump_level }}

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -19,12 +19,13 @@ on:
 
 jobs:
   validate-input:
-    name: build and publish package
+    name: validate inputs
     runs-on: ubuntu-latest
     steps:
-      - if: ${{ startsWith(inputs.bump_level, 'custom') && inputs.custom_bump_level == '' }}
+      - if: ${{ startsWith(inputs.bump_level, 'custom') && inputs.custom_bump_level == null }}
         run: "echo 'custom version indicated but not set' && exit 1"
   build-and-publish:
+    name: build and publish
     needs: [validate-input]
     uses: determined-ai/publish-to-npm-action/.github/workflows/publish-to-npm.yml@v0
     with:

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -35,15 +35,18 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_CLASSIC_TOKEN }}
         run: "echo //registry.npmjs.org/:_authToken=$NPM_TOKEN > ./.npmrc"
-      - if: inputs.bump_level != 'custom'
+      - env:
+          BUMP_LEVEL: ${{ inputs.bump_level }}
+        run: "echo $BUMP_LEVEL"
+      - if: ${{ inputs.bump_level != "custom" }}
         name: "bump version"
         env:
           VERSION: ${{ inputs.bump_level }}
         run: "npm version $VERSION --dry-run"
-      - if: inputs.bump_level == 'custom'
+      - if: ${{ inputs.bump_level == "custom" }}
         name: "custom version bump"
         env:
-          VERSION ${{ inputs.custom_bump_level }}
+          VERSION: ${{ inputs.custom_bump_level }}
         run: "[ -n $VERSION ] && npm version $VERSION --dry-run || (echo 'custom version indicated but not set' && false)"
       - name: "publishing"
         run: "npm publish --dry-run"

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -1,7 +1,7 @@
 name: publish-to-npm
 run-name: ${{ github.actor }} is publishing to npm
 on:
-  workflow-dispatch:
+  workflow_dispatch:
     inputs:
       bump_level:
         description: type of version bump

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -30,5 +30,6 @@ jobs:
     uses: determined-ai/publish-to-npm-action/.github/workflows/publish-to-npm.yml@v0
     with:
       bump_level: ${{ startsWith(inputs.bump_level, 'custom') && inputs.custom_bump_level || inputs.bump_level }}
+      github_token: ${{ github.token }}
     secrets:
       NPM_CLASSIC_TOKEN: ${{ secrets.NPM_CLASSIC_TOKEN }}

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -35,15 +35,12 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_CLASSIC_TOKEN }}
         run: "echo //registry.npmjs.org/:_authToken=$NPM_TOKEN > ./.npmrc"
-      - env:
-          BUMP_LEVEL: ${{ inputs.bump_level }}
-        run: "echo $BUMP_LEVEL"
-      - if: ${{ inputs.bump_level != 'custom' }}
+      - if: ${{ ! startsWith(inputs.bump_level, 'custom') }}
         name: "bump version"
         env:
           VERSION: ${{ inputs.bump_level }}
         run: "npm version $VERSION --dry-run"
-      - if: ${{ inputs.bump_level == 'custom' }}
+      - if: ${{ startsWith(inputs.bump_level, 'custom') }}
         name: "custom version bump"
         env:
           VERSION: ${{ inputs.custom_bump_level }}

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -35,12 +35,12 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_CLASSIC_TOKEN }}
         run: "echo //registry.npmjs.org/:_authToken=$NPM_TOKEN > ./.npmrc"
-      - if: ${{ inputs.bump_level != "custom" }}
+      - if: inputs.bump_level != 'custom'
         name: "bump version"
         env:
           VERSION: ${{ inputs.bump_level }}
         run: "npm version $VERSION --dry-run"
-      - if: ${{ inputs.bump_level == "custom" }}
+      - if: inputs.bump_level == 'custom'
         name: "custom version bump"
         env:
           VERSION ${{ inputs.custom_bump_level }}

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ We're currently unpublished while we set up an NPM organization, so install from
 the github repo like this:
 
 ```bash
-npm install https://git@github.com/determined-ai/hew.git
+npm install @hpe.com/hew
 ```
 
 Components are exported both at the top level module and as individual modules:
 
 ```tsx
-import { Avatar } from 'hew';
-import Card from 'hew/Card';
+import { Avatar } from '@hpe.com/hew';
+import Card from '@hpe.com/hew/Card';
 ```
 
 Related styling is imported alongside the module as a css file. Be sure your
@@ -44,13 +44,12 @@ If the component is in a folder with an index module, remember to add the export
 
 ## How to release
 
-With your changes safely in the main branch, run:
-
-```sh
-npm version patch # also takes minor or major
-```
-
-to bump the version number of the package as well as push it as a git tag for others.
+With your changes safely in the main branch, kick off a new "publish-to-npm"
+workflow in the [actions
+view](https://github.com/determined-ai/hew/actions/workflows/publish-to-npm.yml):
+to bump the version number of the package as well as push it as a git tag for
+others. You can bump to the next major, minor, or patch version, or bump to an
+arbitrary version using the npm version command line.
 
 ## Working between hew and another repo
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hew",
+  "name": "@hpe.com/hew",
   "private": true,
   "version": "0.6.30",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@hpe.com/hew",
-  "private": true,
   "version": "0.6.30",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
This adds a publish action to the hew repo -- this should allow us:

1) not to need to tag new versions of hew using the cli and potentially tagging old versions or versions that aren't main
2) restrict the people allowed to publish new versions of hew to people inside the determined-ai org
3) (ideally) allow protection of the main branch so all code needs to be reviewed.