### PR TITLE
feat: enable tooltip prop for form items

### DIFF
--- a/src/kit/Form.tsx
+++ b/src/kit/Form.tsx
@@ -4,10 +4,7 @@ import {
   FormItemProps as AntdFormItemProps,
   FormProps as AntdFormProps,
 } from 'antd';
-
 import type { LabelTooltipType } from 'antd/es/form/FormItemLabel';
-
-
 import { ErrorListProps } from 'antd/lib/form';
 import { FormListFieldData as AntdFormListFieldData } from 'antd/lib/form/FormList';
 import { FieldData as AntdFieldData, NamePath as AntdNamePath } from 'rc-field-form/lib/interface';

--- a/src/kit/Form.tsx
+++ b/src/kit/Form.tsx
@@ -4,6 +4,10 @@ import {
   FormItemProps as AntdFormItemProps,
   FormProps as AntdFormProps,
 } from 'antd';
+
+import type { LabelTooltipType } from 'antd/es/form/FormItemLabel';
+
+
 import { ErrorListProps } from 'antd/lib/form';
 import { FormListFieldData as AntdFormListFieldData } from 'antd/lib/form/FormList';
 import { FieldData as AntdFieldData, NamePath as AntdNamePath } from 'rc-field-form/lib/interface';
@@ -36,6 +40,7 @@ interface FormItemProps {
   required?: boolean;
   requiredMessage?: string;
   rules?: Rules; // https://ant.design/components/form#rule
+  tooltip?: LabelTooltipType;
   validateMessage?: string;
   validateStatus?: 'success' | 'warning' | 'error' | 'validating';
   validateTrigger?: TriggerEvent[];

--- a/src/kit/Pivot.tsx
+++ b/src/kit/Pivot.tsx
@@ -6,7 +6,7 @@ import { useTheme } from 'kit/Theme';
 
 import css from './Pivot.module.scss';
 
-type TabItem = {
+export type TabItem = {
   children?: ReactNode;
   forceRender?: boolean;
   key: string;


### PR DESCRIPTION
The antD component Form.Item accepts a `tooltip` parameter ([see here for all valid props](https://ant.design/components/form#formitem)), but in hew/form when declaring Form.Item props we do not explicitly allow that prop to be passed in; there is no tooltip in the `FormItemProps` interface. 

In this PR we add this prop and set its type to the type specified in the antD repository used by hew. 

+ additionally, we export a TS type that can be used in other areas of the codebase.

These changes are requested by the SaaS team.  