### PR TITLE
fix: form initial value type

### DIFF
--- a/src/kit/Form.tsx
+++ b/src/kit/Form.tsx
@@ -27,7 +27,7 @@ interface FormItemProps {
   extra?: ReactNode;
   field?: AntdFormListFieldData;
   hidden?: boolean;
-  initialValue?: string | number | Primitive;
+  initialValue?: Primitive | Primitive[];
   label?: ReactNode;
   labelCol?: GridCol; // https://ant.design/components/grid#col
   max?: number;


### PR DESCRIPTION
Cannot pass array type in the original `initialvalue` type in hew Form because it only accepts  string, number, and boolean, but the original antd intialvalue accpet `any` type. This change allows `initialvalue` to have  string, number, and boolean and array of  string, number, and boolean.
If this PR gets merged, we can pass array type in initialvalue for multiple select component.