### PR TITLE
fix: DataGrid header menu bug

### DIFF
--- a/src/DesignKit.tsx
+++ b/src/DesignKit.tsx
@@ -4775,6 +4775,15 @@ const DataGridSection: React.FC = () => {
     }, 1000);
   }, [page]);
 
+  const getHeaderMenuItems = (columnId: string): MenuItem[] => {
+    return [
+      {
+        key: 'header-menu',
+        label: `Header Menu (${columnId})`,
+      },
+    ];
+  };
+
   return (
     <ComponentSection id="DataGrid">
       <SurfaceCard>
@@ -4991,6 +5000,7 @@ const DataGridSection: React.FC = () => {
         <DataGrid<Person>
           columns={columns}
           data={gridData}
+          getHeaderMenuItems={getHeaderMenuItems}
           height={200}
           page={page}
           pageSize={PAGE_SIZE}

--- a/src/kit/DataGrid/menu.tsx
+++ b/src/kit/DataGrid/menu.tsx
@@ -33,23 +33,25 @@ export interface HeaderMenuProps {
 export const HeaderMenu: React.FC<HeaderMenuProps> = ({ bounds, open, handleClose, items }) => {
   const divRef = useRef<HTMLDivElement | null>(null);
   useOutsideClickHandler(divRef, handleClose);
-  if (open) {
-    return (
-      <Dropdown autoWidthOverlay menu={items} open placement="bottomLeft">
-        <div
-          ref={divRef}
-          style={{
-            height: bounds.height,
-            left: bounds.x,
-            position: 'fixed',
-            top: bounds.y,
-            width: bounds.width,
-          }}
-          onClick={handleClose}
-        />
-      </Dropdown>
-    );
-  } else {
-    return <></>;
-  }
+  return (
+    <Dropdown autoWidthOverlay menu={items} open={open} placement="bottomLeft">
+      <div
+        ref={divRef}
+        style={
+          open
+            ? {
+                height: bounds.height,
+                left: bounds.x,
+                position: 'fixed',
+                top: bounds.y,
+                width: bounds.width,
+              }
+            : {
+                display: 'none',
+              }
+        }
+        onClick={handleClose}
+      />
+    </Dropdown>
+  );
 };

--- a/src/kit/DataGrid/menu.tsx
+++ b/src/kit/DataGrid/menu.tsx
@@ -33,23 +33,23 @@ export interface HeaderMenuProps {
 export const HeaderMenu: React.FC<HeaderMenuProps> = ({ bounds, open, handleClose, items }) => {
   const divRef = useRef<HTMLDivElement | null>(null);
   useOutsideClickHandler(divRef, handleClose);
-  return (
-    <Dropdown autoWidthOverlay menu={items} open={open} placement="bottomLeft">
-      <div
-        ref={divRef}
-        style={
-          open
-            ? {
-                height: bounds.height,
-                left: bounds.x,
-                position: 'fixed',
-                top: bounds.y,
-                width: bounds.width,
-              }
-            : {}
-        }
-        onClick={handleClose}
-      />
-    </Dropdown>
-  );
+  if (open) {
+    return (
+      <Dropdown autoWidthOverlay menu={items} open placement="bottomLeft">
+        <div
+          ref={divRef}
+          style={{
+            height: bounds.height,
+            left: bounds.x,
+            position: 'fixed',
+            top: bounds.y,
+            width: bounds.width,
+          }}
+          onClick={handleClose}
+        />
+      </Dropdown>
+    );
+  } else {
+    return <></>;
+  }
 };


### PR DESCRIPTION
This PR fixes a bug where, when closed, header menus would briefly render at the bottom of `DataGrid` before being hidden.

Not sure if this existed in the previous `GlideTable` component in determined. I think that component used `setMenuIsOpen(false)` calls in header menu items' `onClick` handlers to try to address this, but adding that back did not seem to address the bug in the current `DataGrid`.

Fixing it by not rendering the `Dropdown` component at all unless the `open` state value is true.