### PR TITLE
fix: improve chart grid scrolling behavior [ET-42]

### DIFF
--- a/src/DesignKit.tsx
+++ b/src/DesignKit.tsx
@@ -1211,6 +1211,59 @@ const ChartsSection: React.FC = () => {
           xAxis: xAxis,
         })}
         <hr />
+        <strong>Inside scrolling container</strong>
+        <div style={{ height: 500 }}>
+          {createChartGrid({
+            chartsProps: [
+              {
+                series: [line1],
+                showLegend: true,
+                title: 'Sample1',
+                xAxis,
+                xLabel: xAxis,
+              },
+              {
+                series: [line2, line3],
+                showLegend: true,
+                title: 'Sample2',
+                xAxis,
+                xLabel: xAxis,
+              },
+              {
+                series: [line1, line2, line3],
+                showLegend: true,
+                title: 'Sample3',
+                xAxis,
+                xLabel: xAxis,
+              },
+              {
+                series: [line1, line2, line3],
+                showLegend: true,
+                title: 'Sample3',
+                xAxis,
+                xLabel: xAxis,
+              },
+              {
+                series: [line1, line2, line3],
+                showLegend: true,
+                title: 'Sample3',
+                xAxis,
+                xLabel: xAxis,
+              },
+              {
+                series: [line1, line2, line3],
+                showLegend: true,
+                title: 'Sample3',
+                xAxis,
+                xLabel: xAxis,
+              },
+            ],
+            handleError,
+            onXAxisChange: setXAxis,
+            xAxis: xAxis,
+          })}
+        </div>
+        <hr />
         <strong>Loading</strong>
         {createChartGrid({
           chartsProps: NotLoaded,

--- a/src/kit/LineChart.module.scss
+++ b/src/kit/LineChart.module.scss
@@ -4,7 +4,7 @@
   overflow: auto;
 
   .filterContainer {
-    margin-bottom: var(--spacing-lg);
+    padding-bottom: var(--spacing-lg);
   }
   .gridContainer {
     display: grid;

--- a/src/kit/LineChart.module.scss
+++ b/src/kit/LineChart.module.scss
@@ -1,5 +1,6 @@
 .gridBase {
   height: 100%;
+  min-height: 150px;
   overflow: auto;
 
   .filterContainer {

--- a/src/kit/LineChart.tsx
+++ b/src/kit/LineChart.tsx
@@ -302,7 +302,7 @@ export const ChartGrid: React.FC<GroupProps> = React.memo(
     const {
       themeSettings: { className: themeClass },
     } = useTheme();
-    const scrollingContainer = useRef(null);
+    const scrollingContainer = useRef<HTMLDivElement>(null);
     const classes = [css.gridBase, themeClass];
     const chartsProps = Loadable.ensureLoadable(propChartsProps)
       .getOrElse([])

--- a/src/kit/internal/UPlot/UPlotChart.module.scss
+++ b/src/kit/internal/UPlot/UPlotChart.module.scss
@@ -6,7 +6,20 @@
     height: 2px;
   }
   :global(.u-legend) {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-xl);
+    margin: 0;
     text-align: left;
+
+    * {
+      margin: 0;
+    }
+    th {
+      align-items: center;
+      display: flex;
+      gap: 4px;
+    }
   }
 }
 .base.dark {

--- a/src/kit/internal/UPlot/UPlotChart.module.scss
+++ b/src/kit/internal/UPlot/UPlotChart.module.scss
@@ -1,6 +1,5 @@
 .base {
-  margin-bottom: 10px;
-  margin-top: 10px;
+  padding-block: var(--spacing-lg);
   position: relative;
 
   :global(.u-legend .u-marker) {

--- a/src/kit/internal/UPlot/UPlotChart.tsx
+++ b/src/kit/internal/UPlot/UPlotChart.tsx
@@ -218,7 +218,7 @@ const UPlotChart: React.FC<Props> = ({
     const [width, height] = [size.width, options?.height || chartRef.current.height];
     if (chartRef.current.width === width && chartRef.current.height === height) return;
     chartRef.current.setSize({ height, width });
-  }, [options?.height, refObject, size]);
+  }, [options?.height, refObject, size.height, size.width]);
 
   /*
    * Resync the chart when scroll events happen to correct the cursor position upon


### PR DESCRIPTION
On the [react-virtuoso Troubleshooting page](https://virtuoso.dev/troubleshooting/) it says that margins can cause issues scrolling to the bottom, so I went through and removed them.

Scroll up and down on the new "Inside scrolling container" example in the ChartGrid section.