### PR TITLE
fix: fix dark mode screenshots in differ

### DIFF
--- a/src/DesignKit.tsx
+++ b/src/DesignKit.tsx
@@ -5323,7 +5323,8 @@ const DesignKit: React.FC<{
 };
 
 const DesignKitContainer: React.FC = () => {
-  const [mode, setMode] = useState<Mode>(Mode.Light);
+  // needs to be system for screenshot diffs to work for dark mode. Do not change!
+  const [mode, setMode] = useState<Mode>(Mode.System);
   const systemMode = getSystemMode();
 
   const resolvedMode =


### PR DESCRIPTION
this fixes an issue where dark mode screenshots did not show up in the differ. this is because we changed the default theme from system mode to light mode. we default to system mode because the differ uses system preferences to change the theme of the screenshots. I've also added a comment explaining why the default is the way that it is and warning others not to change it.