### PR TITLE
fix: log select bug

### DIFF
--- a/src/kit/LogViewer/LogViewerSelect.tsx
+++ b/src/kit/LogViewer/LogViewerSelect.tsx
@@ -149,7 +149,7 @@ const LogViewerSelect: React.FC<Props> = ({
           mode="multiple"
           placeholder={`All ${LABELS.allocationIds}`}
           value={filters.allocationIds}
-          width={100}
+          width={120}
           onChange={handleChange('allocationIds', String)}>
           {selectOptions?.allocationIds?.map((id, index) => (
             <Option key={id || `no-id-${index}`} value={id}>
@@ -164,7 +164,7 @@ const LogViewerSelect: React.FC<Props> = ({
           mode="multiple"
           placeholder={`All ${LABELS.agentIds}`}
           value={filters.agentIds}
-          width={100}
+          width={120}
           onChange={handleChange('agentIds', String)}>
           {selectOptions?.agentIds?.map((id, index) => (
             <Option key={id || `no-id-${index}`} value={id}>
@@ -179,7 +179,7 @@ const LogViewerSelect: React.FC<Props> = ({
           mode="multiple"
           placeholder={`All ${LABELS.containerIds}`}
           value={filters.containerIds}
-          width={100}
+          width={120}
           onChange={handleChange('containerIds', String)}>
           {selectOptions?.containerIds?.map((id, index) => (
             <Option key={id || `no-id-${index}`} value={id}>
@@ -194,7 +194,7 @@ const LogViewerSelect: React.FC<Props> = ({
           mode="multiple"
           placeholder={`All ${LABELS.rankIds}`}
           value={filters.rankIds}
-          width={100}
+          width={120}
           onChange={handleChange('rankIds', Number)}>
           {selectOptions?.rankIds?.map((id, index) => (
             <Option key={id ?? `no-id-${index}`} value={id}>
@@ -208,7 +208,7 @@ const LogViewerSelect: React.FC<Props> = ({
         mode="multiple"
         placeholder={`All ${LABELS.levels}`}
         value={filters.levels}
-        width={100}
+        width={120}
         onChange={handleChange('levels', String)}>
         {selectOptions?.levels.map((level) => (
           <Option key={level.value} value={level.value}>


### PR DESCRIPTION
[ET-118]

the bug is from #110

---

This is a mild revert from the change of #110 for log selection width. 
There are other bugs around log and selections, but these are out of scope in this PR.

[ET-118]: https://hpe-aiatscale.atlassian.net/browse/ET-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ