### PR TITLE
build: only pack necessary build artifact

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "prettier-check": "prettier --check './**/*.{js,cjs,mjs,ts,tsx,css,less,scss,md,json}'",
     "format": "npm run lint:eslint --fix && npm run lint:stylelint --fix && npm run prettier-write"
   },
+  "files": [
+    "build"
+  ],
   "exports": {
     ".": {
       "import": {


### PR DESCRIPTION
Currently we upload everything in hew folder, but we just want to upload `build` folder to npm registry.
This improves the hew package size. 

```
Unpacked Size: 22.7 MB -> 16.2 MB (around 30% smaller)
Total files: 1018 -> 652
```

### Before

<img width="1236" alt="Screenshot 2024-08-22 at 11 35 57 AM" src="https://github.com/user-attachments/assets/77339566-05a1-4d0c-ac95-df233dc2bf5a">

### After

```bash
npm pack --dry-run
```

<img width="517" alt="image" src="https://github.com/user-attachments/assets/ca09800f-c774-4974-abcd-b520b6c3181e">

## Test

Make sure hew library works after this change
