### PR TITLE
fix: remove unused languages from codeeditor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,11 @@
       "version": "0.6.44",
       "dependencies": {
         "@ant-design/icons": "^5.0.1",
+        "@codemirror/lang-json": "^6.0.1",
+        "@codemirror/lang-markdown": "^6.2.5",
+        "@codemirror/lang-python": "^6.1.6",
+        "@codemirror/lang-yaml": "^6.1.1",
         "@glideapps/glide-data-grid": "^6.0.3",
-        "@uiw/codemirror-extensions-langs": "^4.23.0",
         "@uiw/react-codemirror": "^4.23.0",
         "ansi-to-html": "^0.7.2",
         "antd": "^5.1.7",
@@ -632,30 +635,6 @@
         "@lezer/common": "^1.0.0"
       }
     },
-    "node_modules/@codemirror/lang-angular": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-angular/-/lang-angular-0.1.3.tgz",
-      "integrity": "sha512-xgeWGJQQl1LyStvndWtruUvb4SnBZDAu/gvFH/ZU+c0W25tQR8e5hq7WTwiIY2dNxnf+49mRiGI/9yxIwB6f5w==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/lang-html": "^6.0.0",
-        "@codemirror/lang-javascript": "^6.1.2",
-        "@codemirror/language": "^6.0.0",
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.3.3"
-      }
-    },
-    "node_modules/@codemirror/lang-cpp": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-cpp/-/lang-cpp-6.0.2.tgz",
-      "integrity": "sha512-6oYEYUKHvrnacXxWxYa6t4puTlbN3dgV662BDfSH8+MfjQjVmP697/KYTDOqpxgerkvoNm7q5wlFMBeX8ZMocg==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@lezer/cpp": "^1.0.0"
-      }
-    },
     "node_modules/@codemirror/lang-css": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.2.1.tgz",
@@ -668,23 +647,10 @@
         "@lezer/css": "^1.0.0"
       }
     },
-    "node_modules/@codemirror/lang-go": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-go/-/lang-go-6.0.1.tgz",
-      "integrity": "sha512-7fNvbyNylvqCphW9HD6WFnRpcDjr+KXX/FgqXy5H5ZS0eC5edDljukm/yNgYkwTsgp2busdod50AOTIy6Jikfg==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/autocomplete": "^6.0.0",
-        "@codemirror/language": "^6.6.0",
-        "@codemirror/state": "^6.0.0",
-        "@lezer/common": "^1.0.0",
-        "@lezer/go": "^1.0.0"
-      }
-    },
     "node_modules/@codemirror/lang-html": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.6.tgz",
-      "integrity": "sha512-E4C8CVupBksXvgLSme/zv31x91g06eZHSph7NczVxZW+/K+3XgJGWNT//2WLzaKSBoxpAjaOi5ZnPU1SHhjh3A==",
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.9.tgz",
+      "integrity": "sha512-aQv37pIMSlueybId/2PVSP6NPnmurFDVmZwzc7jszd2KAF8qd4VBbvNYPXWQq90WIARjsdVkPbw29pszmHws3Q==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/lang-css": "^6.0.0",
@@ -697,20 +663,10 @@
         "@lezer/html": "^1.3.0"
       }
     },
-    "node_modules/@codemirror/lang-java": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-java/-/lang-java-6.0.1.tgz",
-      "integrity": "sha512-OOnmhH67h97jHzCuFaIEspbmsT98fNdhVhmA3zCxW0cn7l8rChDhZtwiwJ/JOKXgfm4J+ELxQihxaI7bj7mJRg==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@lezer/java": "^1.0.0"
-      }
-    },
     "node_modules/@codemirror/lang-javascript": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.1.tgz",
-      "integrity": "sha512-jlFOXTejVyiQCW3EQwvKH0m99bUYIw40oPmFjSX2VS78yzfe0HELZ+NEo9Yfo1MkGRpGlj3Gnu4rdxV1EnAs5A==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.2.tgz",
+      "integrity": "sha512-VGQfY+FCc285AhWuwjYxQyUQcYurWlxdKYT4bqwr3Twnd5wP5WSeu52t4tvvuWmljT4EmgEgZCqSieokhtY8hg==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/language": "^6.6.0",
@@ -725,58 +681,15 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.1.tgz",
       "integrity": "sha512-+T1flHdgpqDDlJZ2Lkil/rLiRy684WMLc74xUnjJH48GQdfJo/pudlTRreZmKwzP8/tGdKf83wlbAdOCzlJOGQ==",
-      "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@lezer/json": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/lang-less": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-less/-/lang-less-6.0.2.tgz",
-      "integrity": "sha512-EYdQTG22V+KUUk8Qq582g7FMnCZeEHsyuOJisHRft/mQ+ZSZ2w51NupvDUHiqtsOy7It5cHLPGfHQLpMh9bqpQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/lang-css": "^6.2.0",
-        "@codemirror/language": "^6.0.0",
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/lang-lezer": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-lezer/-/lang-lezer-6.0.1.tgz",
-      "integrity": "sha512-WHwjI7OqKFBEfkunohweqA5B/jIlxaZso6Nl3weVckz8EafYbPZldQEKSDb4QQ9H9BUkle4PVELP4sftKoA0uQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@lezer/common": "^1.0.0",
-        "@lezer/lezer": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/lang-liquid": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-liquid/-/lang-liquid-6.2.1.tgz",
-      "integrity": "sha512-J1Mratcm6JLNEiX+U2OlCDTysGuwbHD76XwuL5o5bo9soJtSbz2g6RU3vGHFyS5DC8rgVmFSzi7i6oBftm7tnA==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/autocomplete": "^6.0.0",
-        "@codemirror/lang-html": "^6.0.0",
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0",
-        "@lezer/common": "^1.0.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.3.1"
       }
     },
     "node_modules/@codemirror/lang-markdown": {
       "version": "6.2.5",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.2.5.tgz",
       "integrity": "sha512-Hgke565YcO4fd9pe2uLYxnMufHO5rQwRr+AAhFq8ABuhkrjyX8R5p5s+hZUTdV60O0dMRjxKhBLxz8pu/MkUVA==",
-      "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.7.1",
         "@codemirror/lang-html": "^6.0.0",
@@ -787,24 +700,10 @@
         "@lezer/markdown": "^1.0.0"
       }
     },
-    "node_modules/@codemirror/lang-php": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-php/-/lang-php-6.0.1.tgz",
-      "integrity": "sha512-ublojMdw/PNWa7qdN5TMsjmqkNuTBD3k6ndZ4Z0S25SBAiweFGyY68AS3xNcIOlb6DDFDvKlinLQ40vSLqf8xA==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/lang-html": "^6.0.0",
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@lezer/common": "^1.0.0",
-        "@lezer/php": "^1.0.0"
-      }
-    },
     "node_modules/@codemirror/lang-python": {
       "version": "6.1.6",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-6.1.6.tgz",
       "integrity": "sha512-ai+01WfZhWqM92UqjnvorkxosZ2aq2u28kHvr+N3gu012XqY2CThD67JPMHnGceRfXPDBmn1HnyqowdpF57bNg==",
-      "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.3.2",
         "@codemirror/language": "^6.8.0",
@@ -813,88 +712,10 @@
         "@lezer/python": "^1.1.4"
       }
     },
-    "node_modules/@codemirror/lang-rust": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-rust/-/lang-rust-6.0.1.tgz",
-      "integrity": "sha512-344EMWFBzWArHWdZn/NcgkwMvZIWUR1GEBdwG8FEp++6o6vT6KL9V7vGs2ONsKxxFUPXKI0SPcWhyYyl2zPYxQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@lezer/rust": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/lang-sass": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-sass/-/lang-sass-6.0.2.tgz",
-      "integrity": "sha512-l/bdzIABvnTo1nzdY6U+kPAC51czYQcOErfzQ9zSm9D8GmNPD0WTW8st/CJwBTPLO8jlrbyvlSEcN20dc4iL0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/lang-css": "^6.2.0",
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@lezer/common": "^1.0.2",
-        "@lezer/sass": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/lang-sql": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-sql/-/lang-sql-6.7.1.tgz",
-      "integrity": "sha512-flQa7zemrLKk0TIrOJnpeyH/b29BcVybtsTeZMgAo40O6kGbrnUSCgwI3TF5iJY3O9VXJKKCA+i0CBVvDfr88w==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/autocomplete": "^6.0.0",
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/lang-vue": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-vue/-/lang-vue-0.1.3.tgz",
-      "integrity": "sha512-QSKdtYTDRhEHCfo5zOShzxCmqKJvgGrZwDQSdbvCRJ5pRLWBS7pD/8e/tH44aVQT6FKm0t6RVNoSUWHOI5vNug==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/lang-html": "^6.0.0",
-        "@codemirror/lang-javascript": "^6.1.2",
-        "@codemirror/language": "^6.0.0",
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.3.1"
-      }
-    },
-    "node_modules/@codemirror/lang-wast": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-wast/-/lang-wast-6.0.2.tgz",
-      "integrity": "sha512-Imi2KTpVGm7TKuUkqyJ5NRmeFWF7aMpNiwHnLQe0x9kmrxElndyH0K6H/gXtWwY6UshMRAhpENsgfpSwsgmC6Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/lang-xml": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-xml/-/lang-xml-6.1.0.tgz",
-      "integrity": "sha512-3z0blhicHLfwi2UgkZYRPioSgVTo9PV5GP5ducFH6FaHy0IAJRg+ixj5gTR1gnT/glAIC8xv4w2VL1LoZfs+Jg==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/autocomplete": "^6.0.0",
-        "@codemirror/language": "^6.4.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0",
-        "@lezer/common": "^1.0.0",
-        "@lezer/xml": "^1.0.0"
-      }
-    },
     "node_modules/@codemirror/lang-yaml": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-yaml/-/lang-yaml-6.1.1.tgz",
       "integrity": "sha512-HV2NzbK9bbVnjWxwObuZh5FuPCowx51mEfoFT9y3y+M37fA3+pbxx4I7uePuygFzDsAmCTwQSc/kXh/flab4uw==",
-      "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/language": "^6.0.0",
@@ -908,7 +729,6 @@
       "version": "6.10.2",
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.10.2.tgz",
       "integrity": "sha512-kgbTYTo0Au6dCSc/TFy7fK3fpJmgHDv1sG1KNQKJXVi+xBTEeBPY/M30YXiU6mMXeH+YIDLsbrT4ZwNRdtF+SA==",
-      "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.23.0",
@@ -916,45 +736,6 @@
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.0.0",
         "style-mod": "^4.0.0"
-      }
-    },
-    "node_modules/@codemirror/language-data": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/language-data/-/language-data-6.5.1.tgz",
-      "integrity": "sha512-0sWxeUSNlBr6OmkqybUTImADFUP0M3P0IiSde4nc24bz/6jIYzqYSgkOSLS+CBIoW1vU8Q9KUWXscBXeoMVC9w==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/lang-angular": "^0.1.0",
-        "@codemirror/lang-cpp": "^6.0.0",
-        "@codemirror/lang-css": "^6.0.0",
-        "@codemirror/lang-go": "^6.0.0",
-        "@codemirror/lang-html": "^6.0.0",
-        "@codemirror/lang-java": "^6.0.0",
-        "@codemirror/lang-javascript": "^6.0.0",
-        "@codemirror/lang-json": "^6.0.0",
-        "@codemirror/lang-less": "^6.0.0",
-        "@codemirror/lang-liquid": "^6.0.0",
-        "@codemirror/lang-markdown": "^6.0.0",
-        "@codemirror/lang-php": "^6.0.0",
-        "@codemirror/lang-python": "^6.0.0",
-        "@codemirror/lang-rust": "^6.0.0",
-        "@codemirror/lang-sass": "^6.0.0",
-        "@codemirror/lang-sql": "^6.0.0",
-        "@codemirror/lang-vue": "^0.1.1",
-        "@codemirror/lang-wast": "^6.0.0",
-        "@codemirror/lang-xml": "^6.0.0",
-        "@codemirror/lang-yaml": "^6.0.0",
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/legacy-modes": "^6.4.0"
-      }
-    },
-    "node_modules/@codemirror/legacy-modes": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.4.1.tgz",
-      "integrity": "sha512-vdg3XY7OAs5uLDx2Iw+cGfnwtd7kM+Et/eMsqAGTfT/JKiVBQZXosTzjEbWAi/FrY6DcQIz8mQjBozFHZEUWQA==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/language": "^6.0.0"
       }
     },
     "node_modules/@codemirror/lint": {
@@ -1694,31 +1475,10 @@
       "integrity": "sha512-yemX0ZD2xS/73llMZIK6KplkjIjf2EvAHcinDi/TfJ9hS25G0388+ClHt6/3but0oOxinTcQHJLDXh6w1crzFQ==",
       "license": "MIT"
     },
-    "node_modules/@lezer/cpp": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@lezer/cpp/-/cpp-1.1.2.tgz",
-      "integrity": "sha512-macwKtyeUO0EW86r3xWQCzOV9/CF8imJLpJlPv3sDY57cPGeUZ8gXWOWNlJr52TVByMV3PayFQCA5SHEERDmVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
     "node_modules/@lezer/css": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.1.3.tgz",
-      "integrity": "sha512-SjSM4pkQnQdJDVc80LYzEaMiNy9txsFbI7HsMgeVF28NdLaAdHNtQ+kB/QqDUzRBV/75NTXjJ/R5IdC8QQGxMg==",
-      "dependencies": {
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
-    "node_modules/@lezer/go": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@lezer/go/-/go-1.0.0.tgz",
-      "integrity": "sha512-co9JfT3QqX1YkrMmourYw2Z8meGC50Ko4d54QEcQbEYpvdUvN4yb0NBZdn/9ertgvjsySxHsKzH3lbm3vqJ4Jw==",
-      "license": "MIT",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.1.8.tgz",
+      "integrity": "sha512-7JhxupKuMBaWQKjQoLtzhGj83DdnZY9MckEOG5+/iLKNK2ZJqKc6hf6uc0HjwCX7Qlok44jBNqZhHKDhEhZYLA==",
       "dependencies": {
         "@lezer/common": "^1.2.0",
         "@lezer/highlight": "^1.0.0",
@@ -1735,20 +1495,9 @@
       }
     },
     "node_modules/@lezer/html": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.6.tgz",
-      "integrity": "sha512-Kk9HJARZTc0bAnMQUqbtuhFVsB4AnteR2BFUWfZV7L/x1H0aAKz6YabrfJ2gk/BEgjh9L3hg5O4y2IDZRBdzuQ==",
-      "dependencies": {
-        "@lezer/common": "^1.0.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
-    "node_modules/@lezer/java": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@lezer/java/-/java-1.1.2.tgz",
-      "integrity": "sha512-3j8X70JvYf0BZt8iSRLXLkt0Ry1hVUgH6wT32yBxH/Xi55nW2VMhc1Az4SKwu4YGSmxCm1fsqDDcHTuFjC8pmg==",
-      "license": "MIT",
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.10.tgz",
+      "integrity": "sha512-dqpT8nISx/p9Do3AchvYGV3qYc4/rKr3IBZxlHmpIKam56P47RSHkSF5f13Vu9hebS1jM0HmtJIwLbWz1VIY6w==",
       "dependencies": {
         "@lezer/common": "^1.2.0",
         "@lezer/highlight": "^1.0.0",
@@ -1756,10 +1505,11 @@
       }
     },
     "node_modules/@lezer/javascript": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.4.7.tgz",
-      "integrity": "sha512-OVWlK0YEi7HM+9JRWtRkir8qvcg0/kVYg2TAMHlVtl6DU1C9yK1waEOLBMztZsV/axRJxsqfJKhzYz+bxZme5g==",
+      "version": "1.4.17",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.4.17.tgz",
+      "integrity": "sha512-bYW4ctpyGK+JMumDApeUzuIezX01H76R1foD6LcRX224FWfyYit/HYxiPGDjXXe/wQWASjCvVGoukTH68+0HIA==",
       "dependencies": {
+        "@lezer/common": "^1.2.0",
         "@lezer/highlight": "^1.1.3",
         "@lezer/lr": "^1.3.0"
       }
@@ -1768,19 +1518,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.2.tgz",
       "integrity": "sha512-xHT2P4S5eeCYECyKNPhr4cbEL9tc8w83SPwRC373o9uEdrvGKTZoJVAGxpOsZckMlEh9W23Pc72ew918RWQOBQ==",
-      "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
-    "node_modules/@lezer/lezer": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@lezer/lezer/-/lezer-1.1.2.tgz",
-      "integrity": "sha512-O8yw3CxPhzYHB1hvwbdozjnAslhhR8A5BH7vfEMof0xk3p+/DFDfZkA9Tde6J+88WgtwaHy4Sy6ThZSkaI0Evw==",
-      "license": "MIT",
-      "dependencies": {
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.0.0"
       }
@@ -1795,61 +1534,18 @@
       }
     },
     "node_modules/@lezer/markdown": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.1.0.tgz",
-      "integrity": "sha512-JYOI6Lkqbl83semCANkO3CKbKc0pONwinyagBufWBm+k4yhIcqfCF8B8fpEpvJLmIy7CAfwiq7dQ/PzUZA340g==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.3.1.tgz",
+      "integrity": "sha512-DGlzU/i8DC8k0uz1F+jeePrkATl0jWakauTzftMQOcbaMkHbNSRki/4E2tOzJWsVpoKYhe7iTJ03aepdwVUXUA==",
       "dependencies": {
         "@lezer/common": "^1.0.0",
         "@lezer/highlight": "^1.0.0"
       }
     },
-    "node_modules/@lezer/php": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@lezer/php/-/php-1.0.2.tgz",
-      "integrity": "sha512-GN7BnqtGRpFyeoKSEqxvGvhJQiI4zkgmYnDk/JIyc7H7Ifc1tkPnUn/R2R8meH3h/aBf5rzjvU8ZQoyiNDtDrA==",
-      "license": "MIT",
-      "dependencies": {
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.1.0"
-      }
-    },
     "node_modules/@lezer/python": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@lezer/python/-/python-1.1.8.tgz",
-      "integrity": "sha512-1T/XsmeF57ijrjpC0Zmrf9YeO5mn2zC1XeSNrOnc0KB+6PgxJ5m7kWKt0CnwyS74oHQXbJxUUL+QDQJR26c1Gw==",
-      "dependencies": {
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
-    "node_modules/@lezer/rust": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@lezer/rust/-/rust-1.0.2.tgz",
-      "integrity": "sha512-Lz5sIPBdF2FUXcWeCu1//ojFAZqzTQNRga0aYv6dYXqJqPfMdCAI0NzajWUd4Xijj1IKJLtjoXRPMvTKWBcqKg==",
-      "license": "MIT",
-      "dependencies": {
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
-    "node_modules/@lezer/sass": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@lezer/sass/-/sass-1.0.6.tgz",
-      "integrity": "sha512-w/RCO2dIzZH1To8p+xjs8cE+yfgGus8NZ/dXeWl/QzHyr+TeBs71qiE70KPImEwvTsmEjoWh0A5SxMzKd5BWBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
-    "node_modules/@lezer/xml": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@lezer/xml/-/xml-1.0.5.tgz",
-      "integrity": "sha512-VFouqOzmUWfIg+tfmpcdV33ewtK+NSwd4ngSe1aG7HFb4BN0ExyY1b8msp+ndFrnlG4V4iC8yXacjFtrwERnaw==",
-      "license": "MIT",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@lezer/python/-/python-1.1.14.tgz",
+      "integrity": "sha512-ykDOb2Ti24n76PJsSa4ZoDF0zH12BSw1LGfQXCYJhJyOGiFTfGaX0Du66Ze72R+u/P35U+O6I9m8TFXov1JzsA==",
       "dependencies": {
         "@lezer/common": "^1.2.0",
         "@lezer/highlight": "^1.0.0",
@@ -1860,7 +1556,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@lezer/yaml/-/yaml-1.0.3.tgz",
       "integrity": "sha512-GuBLekbw9jDBDhGur82nuwkxKQ+a3W5H0GfaAthDXcAu+XdpS43VlnxA9E9hllkpSP5ellRDKjLLj7Lu9Wr6xA==",
-      "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.2.0",
         "@lezer/highlight": "^1.0.0",
@@ -1993,25 +1688,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@nextjournal/lang-clojure": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@nextjournal/lang-clojure/-/lang-clojure-1.0.0.tgz",
-      "integrity": "sha512-gOCV71XrYD0DhwGoPMWZmZ0r92/lIHsqQu9QWdpZYYBwiChNwMO4sbVMP7eTuAqffFB2BTtCSC+1skSH9d3bNg==",
-      "license": "ISC",
-      "dependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@nextjournal/lezer-clojure": "1.0.0"
-      }
-    },
-    "node_modules/@nextjournal/lezer-clojure": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@nextjournal/lezer-clojure/-/lezer-clojure-1.0.0.tgz",
-      "integrity": "sha512-VZyuGu4zw5mkTOwQBTaGVNWmsOZAPw5ZRxu1/Knk/Xfs7EDBIogwIs5UXTYkuECX5ZQB8eOB+wKA2pc7VyqaZQ==",
-      "license": "ISC",
-      "dependencies": {
-        "@lezer/lr": "^1.0.0"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2122,67 +1798,6 @@
       "peerDependencies": {
         "react": ">=16.9.0",
         "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/@replit/codemirror-lang-csharp": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@replit/codemirror-lang-csharp/-/codemirror-lang-csharp-6.2.0.tgz",
-      "integrity": "sha512-6utbaWkoymhoAXj051mkRp+VIJlpwUgCX9Toevz3YatiZsz512fw3OVCedXQx+WcR0wb6zVHjChnuxqfCLtFVQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@codemirror/autocomplete": "^6.0.0",
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0",
-        "@lezer/common": "^1.0.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
-    "node_modules/@replit/codemirror-lang-nix": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@replit/codemirror-lang-nix/-/codemirror-lang-nix-6.0.1.tgz",
-      "integrity": "sha512-lvzjoYn9nfJzBD5qdm3Ut6G3+Or2wEacYIDJ49h9+19WSChVnxv4ojf+rNmQ78ncuxIt/bfbMvDLMeMP0xze6g==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@codemirror/autocomplete": "^6.0.0",
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0",
-        "@lezer/common": "^1.0.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
-    "node_modules/@replit/codemirror-lang-solidity": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@replit/codemirror-lang-solidity/-/codemirror-lang-solidity-6.0.2.tgz",
-      "integrity": "sha512-/dpTVH338KFV6SaDYYSadkB4bI/0B0QRF/bkt1XS3t3QtyR49mn6+2k0OUQhvt2ZSO7kt10J+OPilRAtgbmX0w==",
-      "license": "MIT",
-      "dependencies": {
-        "@lezer/highlight": "^1.2.0"
-      },
-      "peerDependencies": {
-        "@codemirror/language": "^6.0.0"
-      }
-    },
-    "node_modules/@replit/codemirror-lang-svelte": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@replit/codemirror-lang-svelte/-/codemirror-lang-svelte-6.0.0.tgz",
-      "integrity": "sha512-U2OqqgMM6jKelL0GNWbAmqlu1S078zZNoBqlJBW+retTc5M4Mha6/Y2cf4SVg6ddgloJvmcSpt4hHrVoM4ePRA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@codemirror/autocomplete": "^6.0.0",
-        "@codemirror/lang-css": "^6.0.1",
-        "@codemirror/lang-html": "^6.2.0",
-        "@codemirror/lang-javascript": "^6.1.1",
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0",
-        "@lezer/common": "^1.0.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/javascript": "^1.2.0",
-        "@lezer/lr": "^1.0.0"
       }
     },
     "node_modules/@rollup/plugin-alias": {
@@ -3257,48 +2872,6 @@
         "@codemirror/view": ">=6.0.0"
       }
     },
-    "node_modules/@uiw/codemirror-extensions-langs": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-langs/-/codemirror-extensions-langs-4.23.0.tgz",
-      "integrity": "sha512-WUJnTgS3CIV5TZPjwYO+mvRqxfvSSSKC2a+Wm5Uk3uFoZZ7O/GKi4bKKLsIHQkCwNnd9CHJzwN2dpIVrK1AmLA==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/lang-angular": "^0.1.0",
-        "@codemirror/lang-cpp": "^6.0.0",
-        "@codemirror/lang-css": "^6.2.0",
-        "@codemirror/lang-html": "^6.4.0",
-        "@codemirror/lang-java": "^6.0.0",
-        "@codemirror/lang-javascript": "^6.1.0",
-        "@codemirror/lang-json": "^6.0.0",
-        "@codemirror/lang-less": "^6.0.1",
-        "@codemirror/lang-lezer": "^6.0.0",
-        "@codemirror/lang-liquid": "^6.0.1",
-        "@codemirror/lang-markdown": "^6.1.0",
-        "@codemirror/lang-php": "^6.0.0",
-        "@codemirror/lang-python": "^6.1.0",
-        "@codemirror/lang-rust": "^6.0.0",
-        "@codemirror/lang-sass": "^6.0.1",
-        "@codemirror/lang-sql": "^6.4.0",
-        "@codemirror/lang-vue": "^0.1.1",
-        "@codemirror/lang-wast": "^6.0.0",
-        "@codemirror/lang-xml": "^6.0.0",
-        "@codemirror/language-data": ">=6.0.0",
-        "@codemirror/legacy-modes": ">=6.0.0",
-        "@nextjournal/lang-clojure": "^1.0.0",
-        "@replit/codemirror-lang-csharp": "^6.1.0",
-        "@replit/codemirror-lang-nix": "^6.0.1",
-        "@replit/codemirror-lang-solidity": "^6.0.1",
-        "@replit/codemirror-lang-svelte": "^6.0.0",
-        "codemirror-lang-mermaid": "^0.5.0"
-      },
-      "funding": {
-        "url": "https://jaywcjlove.github.io/#/sponsor"
-      },
-      "peerDependencies": {
-        "@codemirror/language-data": ">=6.0.0",
-        "@codemirror/legacy-modes": ">=6.0.0"
-      }
-    },
     "node_modules/@uiw/react-codemirror": {
       "version": "4.23.0",
       "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.23.0.tgz",
@@ -4227,17 +3800,6 @@
         "@codemirror/search": "^6.0.0",
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0"
-      }
-    },
-    "node_modules/codemirror-lang-mermaid": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/codemirror-lang-mermaid/-/codemirror-lang-mermaid-0.5.0.tgz",
-      "integrity": "sha512-Taw/2gPCyNArQJCxIP/HSUif+3zrvD+6Ugt7KJZ2dUKou/8r3ZhcfG8krNTZfV2iu8AuGnymKuo7bLPFyqsh/A==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/language": "^6.9.0",
-        "@lezer/highlight": "^1.1.6",
-        "@lezer/lr": "^1.3.10"
       }
     },
     "node_modules/color-convert": {

--- a/package.json
+++ b/package.json
@@ -61,8 +61,11 @@
   ],
   "dependencies": {
     "@ant-design/icons": "^5.0.1",
+    "@codemirror/lang-json": "^6.0.1",
+    "@codemirror/lang-markdown": "^6.2.5",
+    "@codemirror/lang-python": "^6.1.6",
+    "@codemirror/lang-yaml": "^6.1.1",
     "@glideapps/glide-data-grid": "^6.0.3",
-    "@uiw/codemirror-extensions-langs": "^4.23.0",
     "@uiw/react-codemirror": "^4.23.0",
     "ansi-to-html": "^0.7.2",
     "antd": "^5.1.7",

--- a/src/kit/CodeEditor.tsx
+++ b/src/kit/CodeEditor.tsx
@@ -1,7 +1,3 @@
-import { json } from '@codemirror/lang-json';
-import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
-import { python } from '@codemirror/lang-python';
-import { yaml } from '@codemirror/lang-yaml';
 import ReactCodeMirror, { BasicSetupOptions } from '@uiw/react-codemirror';
 import { Tree } from 'antd';
 import React, { lazy, Suspense, useCallback, useMemo } from 'react';
@@ -11,6 +7,7 @@ import Icon from 'kit/Icon';
 import Message from 'kit/Message';
 import Spinner from 'kit/Spinner';
 import { useTheme } from 'kit/Theme';
+import { langs } from 'kit/utils/codemirrorLanguages';
 import { ErrorHandler } from 'kit/utils/error';
 import { Loadable } from 'kit/utils/loadable';
 import { TreeNode, ValueOf } from 'kit/utils/types';
@@ -21,13 +18,6 @@ const { DirectoryTree } = Tree;
 
 import css from './CodeEditor/CodeEditor.module.scss';
 import './CodeEditor/index.scss';
-
-const langs = {
-  json,
-  markdown: () => markdown({ base: markdownLanguage }),
-  python,
-  yaml,
-};
 
 const MARKDOWN_CONFIG: BasicSetupOptions = {
   autocompletion: false,

--- a/src/kit/CodeEditor.tsx
+++ b/src/kit/CodeEditor.tsx
@@ -1,4 +1,7 @@
-import { langs } from '@uiw/codemirror-extensions-langs';
+import { json } from '@codemirror/lang-json';
+import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
+import { python } from '@codemirror/lang-python';
+import { yaml } from '@codemirror/lang-yaml';
 import ReactCodeMirror, { BasicSetupOptions } from '@uiw/react-codemirror';
 import { Tree } from 'antd';
 import React, { lazy, Suspense, useCallback, useMemo } from 'react';
@@ -18,6 +21,13 @@ const { DirectoryTree } = Tree;
 
 import css from './CodeEditor/CodeEditor.module.scss';
 import './CodeEditor/index.scss';
+
+const langs = {
+  json,
+  markdown: () => markdown({ base: markdownLanguage }),
+  python,
+  yaml,
+};
 
 const MARKDOWN_CONFIG: BasicSetupOptions = {
   autocompletion: false,

--- a/src/kit/internal/CodeMirrorEditor.tsx
+++ b/src/kit/internal/CodeMirrorEditor.tsx
@@ -1,8 +1,8 @@
-import { langs } from '@uiw/codemirror-extensions-langs';
 import ReactCodeMirror, { ReactCodeMirrorProps } from '@uiw/react-codemirror';
 import React from 'react';
 
 import { useTheme } from 'kit/Theme';
+import { langs } from 'kit/utils/codemirrorLanguages';
 
 interface Props extends ReactCodeMirrorProps {
   syntax: keyof typeof langs;

--- a/src/kit/utils/codemirrorLanguages.ts
+++ b/src/kit/utils/codemirrorLanguages.ts
@@ -1,0 +1,12 @@
+import { json } from '@codemirror/lang-json';
+import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
+import { python } from '@codemirror/lang-python';
+import { yaml } from '@codemirror/lang-yaml';
+import { LanguageSupport } from '@codemirror/language';
+
+export const langs = {
+  json,
+  markdown: (): LanguageSupport => markdown({ base: markdownLanguage }),
+  python,
+  yaml,
+};


### PR DESCRIPTION
* remove @uiw/codemirror-extensions-langs: Extra languages were not accessible and only served to bloat build size when consuming apps import the code editor by two megabytes.

* use new yaml languagesupport: the old yaml package and the one included in the extension module did not support code folding.

* reuse github flavored markdown instead of commonmark: github flavored markdown highlights regular links and tables.