### PR TITLE
chore: introduce useMediaQuery

### DIFF
--- a/src/kit/internal/Theme/theme.ts
+++ b/src/kit/internal/Theme/theme.ts
@@ -159,5 +159,12 @@ const subscribeToModeChanges = (callback: () => void) => {
   };
 };
 
+/**
+ * quick note here: useSystemMode doesn't use useMediaQuery because it has to
+ * listen to the "same" media query twice. as such, when the color scheme
+ * changes, useMediaQuery would enqueue two updates -- one for the dark mode
+ * match and one for the light mode match.
+ */
+
 export const useSystemMode = (): Mode =>
   useSyncExternalStore(subscribeToModeChanges, getSystemMode);

--- a/src/kit/useMobile.tsx
+++ b/src/kit/useMobile.tsx
@@ -1,22 +1,8 @@
-import { useEffect, useState } from 'react';
-
 import styles from './scss/breakpoints.module.scss';
+import { useMediaQuery } from './utils/useMediaQuery';
 
 export const MOBILE_BREAKPOINT = styles.breakpointMobile;
 
-const queries = window.matchMedia(`only screen and (max-width: ${MOBILE_BREAKPOINT})`);
-
-const useMobile = (): boolean => {
-  const [isMobile, setIsMobile] = useState(queries.matches);
-  useEffect(() => {
-    const onChange = () => setIsMobile(queries.matches);
-    queries.addEventListener('change', onChange);
-    return () => {
-      queries.removeEventListener('change', onChange);
-    };
-  }, []);
-
-  return isMobile;
-};
+const useMobile = (): boolean => useMediaQuery(`only screen and (max-width: ${MOBILE_BREAKPOINT})`);
 
 export default useMobile;

--- a/src/kit/utils/useMediaQuery.ts
+++ b/src/kit/utils/useMediaQuery.ts
@@ -1,0 +1,18 @@
+import { useMemo, useSyncExternalStore } from 'react';
+
+/**
+ * Given a media query, return the current state of the query. Updates when the query changes.
+ */
+export const useMediaQuery = (query: string): boolean => {
+  const [subscribe, getSnapshot] = useMemo(() => {
+    const match = matchMedia?.(query);
+    return [
+      (notify: () => void) => {
+        match?.addEventListener('change', notify);
+        return () => match?.removeEventListener('change', notify);
+      },
+      () => match?.matches,
+    ];
+  }, [query]);
+  return useSyncExternalStore(subscribe, getSnapshot);
+};


### PR DESCRIPTION
this introduces `useMediaQuery`, a hook that devs can use to listen to the status of a media query. we also replace `useMobile` with this as a wrapper, and explain why we're not replacing `useSystemMode` with it.