### PR TITLE
feat: add column metadata type check

### DIFF
--- a/src/kit/DataGrid/columns.ts
+++ b/src/kit/DataGrid/columns.ts
@@ -45,20 +45,23 @@ export function defaultTextColumn<T extends RawJson>(
   columnTitle: string,
   columnWidth?: number,
   dataPath?: string,
+  columnType?: string,
 ): ColumnDef<T> {
   return {
     id: columnId,
     renderer: (record) => {
-      const [column, columnType] = (dataPath ?? '').split('_'); // for retrieving data based on the metadata type only
-
       const getColumnRecordData = () => {
-        if (columnType) {
-          const value = _.get(record, column);
+        if (dataPath !== undefined) {
+          if (columnType !== undefined) {
+            const value = _.get(record, dataPath);
 
-          return columnType === ColTypes.TEXT ? value : undefined;
+            return columnType === ColTypes.TEXT ? value : undefined;
+          }
+
+          return _.get(record, dataPath);
         }
 
-        return dataPath !== undefined ? _.get(record, dataPath) : undefined;
+        return undefined;
       };
       const recordData = getColumnRecordData();
       const data = typeof recordData === 'string' ? recordData : undefined;
@@ -98,20 +101,23 @@ export function defaultNumberColumn<T extends RawJson>(
   columnWidth?: number,
   dataPath?: string,
   heatmapProps?: HeatmapProps,
+  columnType?: string,
 ): ColumnDef<T> {
   return {
     id: columnId,
     renderer: (record) => {
-      const [column, columnType] = (dataPath ?? '').split('_'); // for retrieving data based on the metadata type only
-
       const getColumnRecordData = () => {
-        if (columnType) {
-          const value = _.get(record, column);
+        if (dataPath !== undefined) {
+          if (columnType !== undefined) {
+            const value = _.get(record, dataPath);
 
-          return columnType === ColTypes.NUMBER ? value : undefined;
+            return columnType === ColTypes.NUMBER ? value : undefined;
+          }
+
+          return _.get(record, dataPath);
         }
 
-        return dataPath !== undefined ? _.get(record, dataPath) : undefined;
+        return undefined;
       };
       const recordData = getColumnRecordData();
       const data = typeof recordData === 'number' ? recordData : undefined;
@@ -169,20 +175,23 @@ export function defaultDateColumn<T extends RawJson>(
   columnTitle: string,
   columnWidth?: number,
   dataPath?: string,
+  columnType?: string,
 ): ColumnDef<T> {
   return {
     id: columnId,
     renderer: (record) => {
-      const [column, columnType] = (dataPath ?? '').split('_'); // for retrieving data based on the metadata type only
-
       const getColumnRecordData = () => {
-        if (columnType) {
-          const value = _.get(record, column);
+        if (dataPath !== undefined) {
+          if (columnType !== undefined) {
+            const value = _.get(record, dataPath);
 
-          return columnType === ColTypes.DATE ? value : undefined;
+            return columnType === ColTypes.DATE ? value : undefined;
+          }
+
+          return _.get(record, dataPath);
         }
 
-        return dataPath !== undefined ? _.get(record, dataPath) : undefined;
+        return undefined;
       };
       const recordData = getColumnRecordData();
       const data = dayjs(recordData).isValid() ? recordData : undefined;
@@ -205,20 +214,23 @@ export function defaultArrayColumn<T extends RawJson>(
   columnTitle: string,
   columnWidth?: number,
   dataPath?: string,
+  columnType?: string,
 ): ColumnDef<T> {
   return {
     id: columnId,
     renderer: (record) => {
-      const [column, columnType] = (dataPath ?? '').split('_'); // for retrieving data based on the metadata type only
-
       const getColumnRecordData = () => {
-        if (columnType) {
-          const value = _.get(record, column);
+        if (dataPath !== undefined) {
+          if (columnType !== undefined) {
+            const value = _.get(record, dataPath);
 
-          return columnType === ColTypes.ARRAY ? value : undefined;
+            return columnType === ColTypes.ARRAY ? value : undefined;
+          }
+
+          return _.get(record, dataPath);
         }
 
-        return dataPath !== undefined ? _.get(record, dataPath) : undefined;
+        return undefined;
       };
       const recordData = getColumnRecordData();
       const data = Array.isArray(recordData) ? recordData : undefined;

--- a/src/kit/DataGrid/columns.ts
+++ b/src/kit/DataGrid/columns.ts
@@ -32,6 +32,13 @@ export interface HeatmapProps {
   max: number;
 }
 
+const typeDic: { [k: string]: string; } = {
+  date: 'string',
+  number: 'number',
+  text: 'string',
+  unspecified: 'boolean',
+};
+
 export function defaultTextColumn<T extends RawJson>(
   columnId: string,
   columnTitle: string,
@@ -41,7 +48,20 @@ export function defaultTextColumn<T extends RawJson>(
   return {
     id: columnId,
     renderer: (record) => {
-      const recordData = dataPath !== undefined ? _.get(record, dataPath) : undefined;
+      const [column, columnType] = (dataPath ?? '').split('_'); // for retrieving data based on the metadata type only
+
+      const getColumnRecordData = () => {
+        if (columnType) {
+          const value = _.get(record, column);
+
+          if (value && typeof value === typeDic[columnType]) return value;
+
+          return undefined;
+        }
+
+        return dataPath !== undefined ? _.get(record, dataPath) : undefined;
+      };
+      const recordData = getColumnRecordData();
       const data = typeof recordData === 'string' ? recordData : undefined;
       return {
         allowOverlay: false,

--- a/src/kit/DataGrid/columns.ts
+++ b/src/kit/DataGrid/columns.ts
@@ -54,7 +54,14 @@ export function defaultTextColumn<T extends RawJson>(
         if (columnType) {
           const value = _.get(record, column);
 
-          if (value && typeof value === typeDic[columnType]) return value;
+          if (value) {
+            if (typeDic[columnType] === 'number') {
+              if (Number.isNaN(Number(value))) return undefined;
+              return value;
+            }
+
+            return value;
+          }
 
           return undefined;
         }

--- a/src/kit/DataGrid/columns.ts
+++ b/src/kit/DataGrid/columns.ts
@@ -19,11 +19,11 @@ export const MIN_COLUMN_WIDTH = 40;
 export const MULTISELECT = 'selected';
 
 export const ColTypes = {
-  ARRAY: 'array',
-  DATE: 'date',
-  NUMBER: 'number',
-  TEXT: 'text',
-  UNSPECIFIED: 'unspecified',
+  ARRAY: 'ARRAY',
+  DATE: 'DATE',
+  NUMBER: 'NUMBER',
+  TEXT: 'TEXT',
+  UNSPECIFIED: 'UNSPECIFIED',
 } as const;
 
 export type ColumnDef<T> = SizedGridColumn & {

--- a/src/kit/DataGrid/columns.ts
+++ b/src/kit/DataGrid/columns.ts
@@ -18,6 +18,14 @@ export const MIN_COLUMN_WIDTH = 40;
 
 export const MULTISELECT = 'selected';
 
+export const ColTypes = {
+  ARRAY: 'array',
+  DATE: 'date',
+  NUMBER: 'number',
+  TEXT: 'text',
+  UNSPECIFIED: 'unspecified',
+} as const;
+
 export type ColumnDef<T> = SizedGridColumn & {
   id: string;
   type?: 'number' | 'text' | 'date' | 'array' | 'unspecified';
@@ -31,13 +39,6 @@ export interface HeatmapProps {
   min: number;
   max: number;
 }
-
-const typeDic: { [k: string]: string; } = {
-  date: 'string',
-  number: 'number',
-  text: 'string',
-  unspecified: 'boolean',
-};
 
 export function defaultTextColumn<T extends RawJson>(
   columnId: string,
@@ -54,16 +55,7 @@ export function defaultTextColumn<T extends RawJson>(
         if (columnType) {
           const value = _.get(record, column);
 
-          if (value) {
-            if (typeDic[columnType] === 'number') {
-              if (Number.isNaN(Number(value))) return undefined;
-              return value;
-            }
-
-            return value;
-          }
-
-          return undefined;
+          return columnType === ColTypes.TEXT ? value : undefined;
         }
 
         return dataPath !== undefined ? _.get(record, dataPath) : undefined;
@@ -110,7 +102,18 @@ export function defaultNumberColumn<T extends RawJson>(
   return {
     id: columnId,
     renderer: (record) => {
-      const recordData = dataPath !== undefined ? _.get(record, dataPath) : undefined;
+      const [column, columnType] = (dataPath ?? '').split('_'); // for retrieving data based on the metadata type only
+
+      const getColumnRecordData = () => {
+        if (columnType) {
+          const value = _.get(record, column);
+
+          return columnType === ColTypes.NUMBER ? value : undefined;
+        }
+
+        return dataPath !== undefined ? _.get(record, dataPath) : undefined;
+      };
+      const recordData = getColumnRecordData();
       const data = typeof recordData === 'number' ? recordData : undefined;
       let theme: Partial<GTheme> = {};
       if (heatmapProps && data !== undefined) {
@@ -170,7 +173,18 @@ export function defaultDateColumn<T extends RawJson>(
   return {
     id: columnId,
     renderer: (record) => {
-      const recordData = dataPath !== undefined ? _.get(record, dataPath) : undefined;
+      const [column, columnType] = (dataPath ?? '').split('_'); // for retrieving data based on the metadata type only
+
+      const getColumnRecordData = () => {
+        if (columnType) {
+          const value = _.get(record, column);
+
+          return columnType === ColTypes.DATE ? value : undefined;
+        }
+
+        return dataPath !== undefined ? _.get(record, dataPath) : undefined;
+      };
+      const recordData = getColumnRecordData();
       const data = dayjs(recordData).isValid() ? recordData : undefined;
       return {
         allowOverlay: false,
@@ -195,7 +209,18 @@ export function defaultArrayColumn<T extends RawJson>(
   return {
     id: columnId,
     renderer: (record) => {
-      const recordData = dataPath !== undefined ? _.get(record, dataPath) : undefined;
+      const [column, columnType] = (dataPath ?? '').split('_'); // for retrieving data based on the metadata type only
+
+      const getColumnRecordData = () => {
+        if (columnType) {
+          const value = _.get(record, column);
+
+          return columnType === ColTypes.ARRAY ? value : undefined;
+        }
+
+        return dataPath !== undefined ? _.get(record, dataPath) : undefined;
+      };
+      const recordData = getColumnRecordData();
       const data = Array.isArray(recordData) ? recordData : undefined;
       return {
         allowOverlay: false,


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->

[ET-791](https://hpe-aiatscale.atlassian.net/browse/ET-791)



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->

Right now, if we have multiple metadata columns with the same name, there's no quick way of knowing of which type each one is while selecting it. This PR intends to add a descriptive badge next to duplicate entries for the metadata columns.



## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->

- make sure that you have at least one metadata column that is duplicated and of a different type
- go to a experiment list
  - make sure that the grid visualization is enabled
- open the column picker
- verify that the duplicates has a `<column_name> <column_type_tag>` format

<img width="1480" alt="Screenshot 2024-10-14 at 16 58 13" src="https://github.com/user-attachments/assets/94b28e84-718b-400b-a587-cf839c4c0577">

<img width="1481" alt="Screenshot 2024-10-14 at 16 59 27" src="https://github.com/user-attachments/assets/8a003186-8649-4b67-abd4-3f914474689e">

![Screenshot 2024-10-21 at 11 12 49](https://github.com/user-attachments/assets/457399df-c26d-4f86-8ed9-e1e4b555bf8d)

![Screenshot 2024-10-21 at 11 12 42](https://github.com/user-attachments/assets/a767e2c2-3b24-43b0-a4c1-d2bcd4cceac8)

![Screenshot 2024-10-21 at 11 13 43](https://github.com/user-attachments/assets/4b806554-37e1-44a1-8778-64de6ab3a2df)

![Screenshot 2024-10-18 at 17 44 26](https://github.com/user-attachments/assets/e398c1d5-300c-4761-992e-0e64a89a887c)



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[ET-790]: https://hpe-aiatscale.atlassian.net/browse/ET-790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ET-791]: https://hpe-aiatscale.atlassian.net/browse/ET-791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ