### PR TITLE
fix: close icon in makeToast popup should have theme

### DIFF
--- a/src/kit/Toast.tsx
+++ b/src/kit/Toast.tsx
@@ -71,7 +71,11 @@ export const makeToast = ({
 }: ToastArgs): void => {
   const args = {
     className: css.notification,
-    closeIcon: closeable ? <Icon decorative name="close" /> : null,
+    closeIcon: closeable ? (
+      <ToastThemeProvider>
+        <Icon decorative name="close" />
+      </ToastThemeProvider>
+    ) : null,
     description: description ? (
       link ? (
         <div>


### PR DESCRIPTION
This was causing the following error in tests if a non-silent handleError was called.
```
Error: useStore(UI) must be used within a UIProvider
```